### PR TITLE
Go: add raw string literal syntax

### DIFF
--- a/src/go.ts
+++ b/src/go.ts
@@ -126,6 +126,7 @@ export var language = <ILanguage> {
 			// strings
 			[/"([^"\\]|\\.)*$/, 'string.invalid' ],  // non-teminated string
 			[/"/,  'string', '@string' ],
+			[/`/, "string", "@rawstring"],
 
 			// characters
 			[/'[^\\']'/, 'string'],
@@ -161,6 +162,11 @@ export var language = <ILanguage> {
 			[/@escapes/, 'string.escape'],
 			[/\\./,      'string.escape.invalid'],
 			[/"/,        'string', '@pop' ]
+		],
+
+		rawstring: [
+			[/[^\`]/, "string"],
+			[/`/, "string", "@pop"]
 		],
 	},
 };

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -1163,5 +1163,11 @@ testTokenization('go', [
 	line: '}',
 	tokens: [
 		{ startIndex: 0, type: 'delimiter.curly.go' }
+	]}],
+
+	[{
+	line: '`Hello world() ""`',
+	tokens: [
+		{ startIndex: 0, type: 'string.go' }
 	]}]
 ]);


### PR DESCRIPTION
Go allows raw string literals using backquotes:
https://golang.org/ref/spec#String_literals

I'm not sure what the rules are on escaping inside raw string literals. This PR could be a starting point.

Thanks!