### PR TITLE
Include src as a part of npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 /.vscode/
 /out/
-/src/
 /test/
 /gulpfile.js
 /tsconfig.json


### PR DESCRIPTION
It would be nice to consume sources as it is to bundle it with not amd loader, e.g. it is hard to consume generated amd modules with webpack.