### PR TITLE
Update Dockerfile grammar with STOPSIGNAL and SHELL instructions

### DIFF
--- a/src/dockerfile.ts
+++ b/src/dockerfile.ts
@@ -34,7 +34,7 @@ export const language = <ILanguage>{
 	defaultToken: '',
 	tokenPostfix: '.dockerfile',
 
-	instructions: /FROM|MAINTAINER|RUN|EXPOSE|ENV|ADD|VOLUME|LABEL|USER|WORKDIR|COPY|CMD|ENTRYPOINT/,
+	instructions: /FROM|MAINTAINER|RUN|EXPOSE|ENV|ADD|VOLUME|LABEL|USER|WORKDIR|COPY|CMD|STOPSIGNAL|SHELL|ENTRYPOINT/,
 
 	instructionAfter: /ONBUILD/,
 


### PR DESCRIPTION
Docker added `SHELL` and `STOPSIGNAL` instructions in 1.12. These should be included in the dockerfile.ts language definition file.