### PR TITLE
Add LIMIT to sql keywords

### DIFF
--- a/src/sql.ts
+++ b/src/sql.ts
@@ -456,6 +456,7 @@ export const language = <ILanguage>{
 		'LEVEL_3',
 		'LEVEL_4',
 		'LIFETIME',
+		'LIMIT',
 		'LINENO',
 		'LIST',
 		'LISTENER',


### PR DESCRIPTION
I think `LIMIT` should be an included keyword for SQL, considering `OFFSET` is already included in the list