### PR TITLE
Support Content-Security-Policy syntax highlighting 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,7 +81,8 @@ gulp.task('release', ['clean-release','compile'], function() {
 			bundleOne('src/mysql'),
 			bundleOne('src/redshift'),
 			bundleOne('src/pgsql'),
-			bundleOne('src/redis')
+			bundleOne('src/redis'),
+			bundleOne('src/csp')
 		)
 		.pipe(uglify({
 			output: {

--- a/src/csp.ts
+++ b/src/csp.ts
@@ -1,0 +1,47 @@
+// Create your own language definition here
+// You can safely look at other samples without losing modifications.
+// Modifications are not saved on browser refresh/close though -- copy often!
+return {
+  // Set defaultToken to invalid to see what you do not tokenize yet
+  // defaultToken: 'invalid',
+  keywords: [],
+  typeKeywords: [],
+  operators: [],
+  symbols:  /[=><!~?:&|+\-*\/\^%]+/,
+  escapes: /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
+  tokenizer: {
+    root: [
+      [/child-src/,                   'string.quote'],
+      [/connect-src/,                 'string.quote'],
+      [/default-src/,                 'string.quote'],
+      [/font-src/,                    'string.quote'],
+      [/frame-src/,                   'string.quote'],
+      [/img-src/,                     'string.quote'],
+      [/manifest-src/,                'string.quote'],
+      [/media-src/,                   'string.quote'],
+      [/object-src/,                  'string.quote'],
+      [/script-src/,                  'string.quote'],
+      [/style-src/,                   'string.quote'],
+      [/worker-src/,                  'string.quote'],
+      [/base-uri/,                    'string.quote'],
+      [/plugin-types/,                'string.quote'],
+      [/sandbox/,                     'string.quote'],
+      [/disown-opener/,               'string.quote'],
+      [/form-action/,                 'string.quote'],
+      [/frame-ancestors/,             'string.quote'],
+      [/report-uri/,                  'string.quote'],
+      [/report-to/,                   'string.quote'],
+      [/upgrade-insecure-requests/,   'string.quote'],
+      [/block-all-mixed-content/,     'string.quote'],
+      [/require-sri-for/,             'string.quote'],
+      [/reflected-xss/,               'string.quote'],
+      [/referrer/,                    'string.quote'],
+      [/policy-uri/,                  'string.quote'],
+      [/'self'/,                      'string.quote'],
+      [/'unsafe-inline'/,             'string.quote'],
+      [/'unsafe-eval'/,               'string.quote'],
+      [/'strict-dynamic'/,            'string.quote'],
+      [/'unsafe-hashed-attributes'/,  'string.quote']
+    ]
+  }
+};

--- a/src/csp.ts
+++ b/src/csp.ts
@@ -1,47 +1,61 @@
-// Create your own language definition here
-// You can safely look at other samples without losing modifications.
-// Modifications are not saved on browser refresh/close though -- copy often!
-return {
-  // Set defaultToken to invalid to see what you do not tokenize yet
-  // defaultToken: 'invalid',
-  keywords: [],
-  typeKeywords: [],
-  operators: [],
-  symbols:  /[=><!~?:&|+\-*\/\^%]+/,
-  escapes: /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
-  tokenizer: {
-    root: [
-      [/child-src/,                   'string.quote'],
-      [/connect-src/,                 'string.quote'],
-      [/default-src/,                 'string.quote'],
-      [/font-src/,                    'string.quote'],
-      [/frame-src/,                   'string.quote'],
-      [/img-src/,                     'string.quote'],
-      [/manifest-src/,                'string.quote'],
-      [/media-src/,                   'string.quote'],
-      [/object-src/,                  'string.quote'],
-      [/script-src/,                  'string.quote'],
-      [/style-src/,                   'string.quote'],
-      [/worker-src/,                  'string.quote'],
-      [/base-uri/,                    'string.quote'],
-      [/plugin-types/,                'string.quote'],
-      [/sandbox/,                     'string.quote'],
-      [/disown-opener/,               'string.quote'],
-      [/form-action/,                 'string.quote'],
-      [/frame-ancestors/,             'string.quote'],
-      [/report-uri/,                  'string.quote'],
-      [/report-to/,                   'string.quote'],
-      [/upgrade-insecure-requests/,   'string.quote'],
-      [/block-all-mixed-content/,     'string.quote'],
-      [/require-sri-for/,             'string.quote'],
-      [/reflected-xss/,               'string.quote'],
-      [/referrer/,                    'string.quote'],
-      [/policy-uri/,                  'string.quote'],
-      [/'self'/,                      'string.quote'],
-      [/'unsafe-inline'/,             'string.quote'],
-      [/'unsafe-eval'/,               'string.quote'],
-      [/'strict-dynamic'/,            'string.quote'],
-      [/'unsafe-hashed-attributes'/,  'string.quote']
-    ]
-  }
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import IRichLanguageConfiguration = monaco.languages.LanguageConfiguration;
+import ILanguage = monaco.languages.IMonarchLanguage;
+
+export const conf: IRichLanguageConfiguration = {
+	brackets: [],
+	autoClosingPairs: [],
+	surroundingPairs: []
+};
+
+export const language = <ILanguage>{
+	// Set defaultToken to invalid to see what you do not tokenize yet
+	// defaultToken: 'invalid',
+	keywords: [],
+	typeKeywords: [],
+	tokenPostfix: '.csp',
+	operators: [],
+	symbols:  /[=><!~?:&|+\-*\/\^%]+/,
+	escapes: /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
+	tokenizer: {
+		root: [
+			[/child-src/,                   'string.quote'],
+			[/connect-src/,                 'string.quote'],
+			[/default-src/,                 'string.quote'],
+			[/font-src/,                    'string.quote'],
+			[/frame-src/,                   'string.quote'],
+			[/img-src/,                     'string.quote'],
+			[/manifest-src/,                'string.quote'],
+			[/media-src/,                   'string.quote'],
+			[/object-src/,                  'string.quote'],
+			[/script-src/,                  'string.quote'],
+			[/style-src/,                   'string.quote'],
+			[/worker-src/,                  'string.quote'],
+			[/base-uri/,                    'string.quote'],
+			[/plugin-types/,                'string.quote'],
+			[/sandbox/,                     'string.quote'],
+			[/disown-opener/,               'string.quote'],
+			[/form-action/,                 'string.quote'],
+			[/frame-ancestors/,             'string.quote'],
+			[/report-uri/,                  'string.quote'],
+			[/report-to/,                   'string.quote'],
+			[/upgrade-insecure-requests/,   'string.quote'],
+			[/block-all-mixed-content/,     'string.quote'],
+			[/require-sri-for/,             'string.quote'],
+			[/reflected-xss/,               'string.quote'],
+			[/referrer/,                    'string.quote'],
+			[/policy-uri/,                  'string.quote'],
+			[/'self'/,                      'string.quote'],
+			[/'unsafe-inline'/,             'string.quote'],
+			[/'unsafe-eval'/,               'string.quote'],
+			[/'strict-dynamic'/,            'string.quote'],
+			[/'unsafe-hashed-attributes'/,  'string.quote']
+		]
+	}
 };

--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -300,3 +300,10 @@ registerLanguage({
 	aliases: ['redis'],
 	module: './redis'
 });
+
+registerLanguage({
+	id: 'csp',
+	extensions: [],
+	aliases: ['CSP', 'csp'],
+	module: './csp'
+});

--- a/test/all.js
+++ b/test/all.js
@@ -62,7 +62,8 @@ requirejs([
 		'out/test/mysql.test',
 		'out/test/pgsql.test',
 		'out/test/redshift.test',
-		'out/test/redis.test'
+		'out/test/redis.test',
+		'out/test/csp.test',
 	], function() {
 		run(); // We can launch the tests!
 	});

--- a/test/csp.test.ts
+++ b/test/csp.test.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { testTokenization } from './testRunner';
+
+testTokenization('csp', []);


### PR DESCRIPTION
Content-Security-Policy is a great W3C standard to prevent XSS attacks. We would love to contribute the syntax highlighting for it.

https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy