### PR TITLE
Whitespaces after # are allowed in C++ preprocessor statements (Microsoft/monaco-editor#687)

### DIFF
--- a/src/cpp.ts
+++ b/src/cpp.ts
@@ -259,7 +259,7 @@ export const language = <ILanguage>{
 			[/\[\[.*\]\]/, 'annotation'],
 
 			// Preprocessor directive
-			[/^\s*#\w+/, 'keyword'],
+			[/^\s*#\s*\w+/, 'keyword'],
 
 			// delimiters and operators
 			[/[{}()\[\]]/, '@brackets'],

--- a/test/cpp.test.ts
+++ b/test/cpp.test.ts
@@ -747,5 +747,34 @@ testTokenization('cpp', [
 		tokens: [
 			{ startIndex: 0, type: 'keyword.cpp' }
 		]
+	}, {
+		line: '#    ifdef VAR',
+		tokens: [
+			{ startIndex: 0, type: 'keyword.cpp' },
+			{ startIndex: 10, type: '' },
+			{ startIndex: 11, type: 'identifier.cpp' }
+		]
+	}, {
+		line: '#	define SUM(A,B) (A) + (B)',
+		tokens: [
+			{ startIndex: 0, type: 'keyword.cpp' },
+			{ startIndex: 8, type: '' },
+			{ startIndex: 9, type: 'identifier.cpp' },
+			{ startIndex: 12, type: 'delimiter.parenthesis.cpp' },
+			{ startIndex: 13, type: 'identifier.cpp' },
+			{ startIndex: 14, type: 'delimiter.cpp' },
+			{ startIndex: 15, type: 'identifier.cpp' },
+			{ startIndex: 16, type: 'delimiter.parenthesis.cpp' },
+			{ startIndex: 17, type: '' },
+			{ startIndex: 18, type: 'delimiter.parenthesis.cpp' },
+			{ startIndex: 19, type: 'identifier.cpp' },
+			{ startIndex: 20, type: 'delimiter.parenthesis.cpp' },
+			{ startIndex: 21, type: '' },
+			{ startIndex: 22, type: 'delimiter.cpp' },
+			{ startIndex: 23, type: '' },
+			{ startIndex: 24, type: 'delimiter.parenthesis.cpp' },
+			{ startIndex: 25, type: 'identifier.cpp' },
+			{ startIndex: 26, type: 'delimiter.parenthesis.cpp' }
+		]
 	}]
 ]);


### PR DESCRIPTION
This pull request fix issue Microsoft/monaco-editor#687.