### PR TITLE
Improve tokenization of regular expressions

### DIFF
--- a/src/javascript/javascript.test.ts
+++ b/src/javascript/javascript.test.ts
@@ -430,7 +430,7 @@ testTokenization('javascript', [
 		]
 	}],
 
-[{
+	[{
 		line: 'x = /foo/.test(\'\')',
 		tokens: [
 			{ startIndex: 0, type: 'identifier.js' },
@@ -443,6 +443,39 @@ testTokenization('javascript', [
 			{ startIndex: 14, type: 'delimiter.parenthesis.js' },
 			{ startIndex: 15, type: 'string.js' },
 			{ startIndex: 17, type: 'delimiter.parenthesis.js' }
+		]
+	}],
+
+	[{
+		line: '/foo/',
+		tokens: [
+			{ startIndex: 0, type: 'regexp.js' }
+		]
+	}],
+
+	[{
+		line: '/foo/g',
+		tokens: [
+			{ startIndex: 0, type: 'regexp.js' },
+			{ startIndex: 5, type: 'keyword.other.js' }
+		]
+	}],
+
+	[{
+		line: '/foo/gimsuy',
+		tokens: [
+			{ startIndex: 0, type: 'regexp.js' },
+			{ startIndex: 5, type: 'keyword.other.js' }
+		]
+	}],
+
+	[{
+		line: '/foo/q', // invalid flag
+		tokens: [
+			{ startIndex: 0, type: 'delimiter.js' },
+			{ startIndex: 1, type: 'identifier.js' },
+			{ startIndex: 4, type: 'delimiter.js' },
+			{ startIndex: 5, type: 'identifier.js' }
 		]
 	}],
 

--- a/src/typescript/typescript.test.ts
+++ b/src/typescript/typescript.test.ts
@@ -447,6 +447,39 @@ testTokenization('typescript', [
 	}],
 
 	[{
+		line: '/foo/',
+		tokens: [
+			{ startIndex: 0, type: 'regexp.ts' }
+		]
+	}],
+
+	[{
+		line: '/foo/g',
+		tokens: [
+			{ startIndex: 0, type: 'regexp.ts' },
+			{ startIndex: 5, type: 'keyword.other.ts' }
+		]
+	}],
+
+	[{
+		line: '/foo/gimsuy',
+		tokens: [
+			{ startIndex: 0, type: 'regexp.ts' },
+			{ startIndex: 5, type: 'keyword.other.ts' }
+		]
+	}],
+
+	[{
+		line: '/foo/q', // invalid flag
+		tokens: [
+			{ startIndex: 0, type: 'delimiter.ts' },
+			{ startIndex: 1, type: 'identifier.ts' },
+			{ startIndex: 4, type: 'delimiter.ts' },
+			{ startIndex: 5, type: 'identifier.ts' }
+		]
+	}],
+
+	[{
 		line: 'x = 1 + f(2 / 3, /foo/)',
 		tokens: [
 			{ startIndex: 0, type: 'identifier.ts' },

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -190,7 +190,7 @@ export const language = {
 			[/[^\\\/]/, 'regexp'],
 			[/@regexpesc/, 'regexp.escape'],
 			[/\\\./, 'regexp.invalid'],
-			['/', { token: 'regexp', bracket: '@close' }, '@pop'],
+			[/(\/)([gimsuy]*)/, [{ token: 'regexp', bracket: '@close', next: '@pop' }, 'keyword.other']],
 		],
 
 		regexrange: [

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -130,7 +130,7 @@ export const language = {
 			{ include: '@whitespace' },
 
 			// regular expression: ensure it is terminated before beginning (otherwise it is an opeator)
-			[/\/(?=([^\\\/]|\\.)+\/([gimuy]*)(\s*)(\.|;|\/|,|\)|\]|\}|$))/, { token: 'regexp', bracket: '@open', next: '@regexp' }],
+			[/\/(?=([^\\\/]|\\.)+\/([gimsuy]*)(\s*)(\.|;|\/|,|\)|\]|\}|$))/, { token: 'regexp', bracket: '@open', next: '@regexp' }],
 
 			// delimiters and operators
 			[/[()\[\]]/, '@brackets'],


### PR DESCRIPTION
Hi,

this PR does three things
1. Recognize `s` as a valid regular expression flag
2. Tokenize the flag part of regular expressions as `keyword.other` like VS Code does
3. Add more tests for regular expressions

Let me know what you think.

Thanks!