### PR TITLE
New rule for non-teminated string in yaml

### DIFF
--- a/src/yaml/yaml.test.ts
+++ b/src/yaml/yaml.test.ts
@@ -145,6 +145,15 @@ testTokenization('yaml', [
 		}]
 	}],
 
+	//String
+	[{
+		line: '\'\'\'',
+		tokens: [
+			{ startIndex: 0, type: 'string.yaml' },
+			{ startIndex: 2, type: 'string.invalid.yaml' },
+		]
+	}],
+
 	// Block Scalar
 	[{
 		line: '>',

--- a/src/yaml/yaml.ts
+++ b/src/yaml/yaml.ts
@@ -202,6 +202,8 @@ export const language = <ILanguage>{
 
 		// Start Flow Scalars (quoted strings)
 		flowScalars: [
+			[/"([^"\\]|\\.)*$/, 'string.invalid'],
+			[/'([^'\\]|\\.)*$/, 'string.invalid'],
 			[/"/, 'string', '@string."'],
 			[/'/, 'string', '@string.\'']
 		],


### PR DESCRIPTION
- Update test
- Rule for non-teminated string return `string.invalid.yaml`