### PR TITLE
[JS/TS] Add support for alternative octal integer literal syntax

### DIFF
--- a/src/javascript/javascript.test.ts
+++ b/src/javascript/javascript.test.ts
@@ -375,6 +375,27 @@ testTokenization('javascript', [
 		]
 	}],
 
+	[{
+		line: '0X123',
+		tokens: [
+			{ startIndex: 0, type: 'number.hex.js' }
+		]
+	}],
+
+	[{
+		line: '0b101',
+		tokens: [
+			{ startIndex: 0, type: 'number.binary.js' }
+		]
+	}],
+
+	[{
+		line: '0B101',
+		tokens: [
+			{ startIndex: 0, type: 'number.binary.js' }
+		]
+	}],
+
 	// Regular Expressions
 	[{
 		line: '//',

--- a/src/javascript/javascript.test.ts
+++ b/src/javascript/javascript.test.ts
@@ -347,6 +347,20 @@ testTokenization('javascript', [
 	}],
 
 	[{
+		line: '0o123',
+		tokens: [
+			{ startIndex: 0, type: 'number.octal.js' }
+		]
+	}],
+
+	[{
+		line: '0O123',
+		tokens: [
+			{ startIndex: 0, type: 'number.octal.js' }
+		]
+	}],
+
+	[{
 		line: '0x',
 		tokens: [
 			{ startIndex: 0, type: 'number.js' },

--- a/src/typescript/typescript.test.ts
+++ b/src/typescript/typescript.test.ts
@@ -347,6 +347,20 @@ testTokenization('typescript', [
 	}],
 
 	[{
+		line: '0o123',
+		tokens: [
+			{ startIndex: 0, type: 'number.octal.ts' }
+		]
+	}],
+
+	[{
+		line: '0O123',
+		tokens: [
+			{ startIndex: 0, type: 'number.octal.ts' }
+		]
+	}],
+
+	[{
 		line: '0x',
 		tokens: [
 			{ startIndex: 0, type: 'number.ts' },

--- a/src/typescript/typescript.test.ts
+++ b/src/typescript/typescript.test.ts
@@ -375,6 +375,27 @@ testTokenization('typescript', [
 		]
 	}],
 
+	[{
+		line: '0X123',
+		tokens: [
+			{ startIndex: 0, type: 'number.hex.ts' }
+		]
+	}],
+
+	[{
+		line: '0b101',
+		tokens: [
+			{ startIndex: 0, type: 'number.binary.ts' }
+		]
+	}],
+
+	[{
+		line: '0B101',
+		tokens: [
+			{ startIndex: 0, type: 'number.binary.ts' }
+		]
+	}],
+
 	// Regular Expressions
 	[{
 		line: '//',

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -146,7 +146,7 @@ export const language = {
 			[/(@digits)[eE]([\-+]?(@digits))?/, 'number.float'],
 			[/(@digits)\.(@digits)([eE][\-+]?(@digits))?/, 'number.float'],
 			[/0[xX](@hexdigits)/, 'number.hex'],
-			[/0(@octaldigits)/, 'number.octal'],
+			[/0[oO]?(@octaldigits)/, 'number.octal'],
 			[/0[bB](@binarydigits)/, 'number.binary'],
 			[/(@digits)/, 'number'],
 


### PR DESCRIPTION
Hi,

according to the [ECMAScript spec](https://tc39.github.io/ecma262/#prod-OctalIntegerLiteral) octal integer literals can also be of the form `0o123` or `0O123`. This PR adds support for that syntax and also adds some more tests for hex and binary integer literals.

Thanks!