### PR TITLE
Use C# highlighting for Cake scripts

### DIFF
--- a/src/csharp/csharp.contribution.ts
+++ b/src/csharp/csharp.contribution.ts
@@ -11,7 +11,7 @@ const _monaco: typeof monaco = (typeof monaco === 'undefined' ? (<any>self).mona
 
 registerLanguage({
 	id: 'csharp',
-	extensions: ['.cs', '.csx'],
+	extensions: ['.cs', '.csx', '.cake'],
 	aliases: ['C#', 'csharp'],
 	loader: () => _monaco.Promise.wrap(import('./csharp'))
 });


### PR DESCRIPTION
As Cake scripts are C# scripts it would be nice to have them syntax highlighted