### PR TITLE
Solidity - add "constructor" to main keywords

### DIFF
--- a/src/solidity/solidity.ts
+++ b/src/solidity/solidity.ts
@@ -43,6 +43,7 @@ export const language = <ILanguage>{
 		'struct',
 		'function',
 		'modifier',
+		'constructor',
 		//Built-in types
 		'address',
 		'string',


### PR DESCRIPTION
Since Solidity v0.4.23, Solidity has new constructor notation.

```
contract Foo {
  constructor() public {
    // ...
  }
}