### PR TITLE
Update ruby auto indentation rules

### DIFF
--- a/src/ruby/ruby.ts
+++ b/src/ruby/ruby.ts
@@ -31,7 +31,11 @@ export const conf: IRichLanguageConfiguration = {
 		{ open: '(', close: ')' },
 		{ open: '"', close: '"' },
 		{ open: '\'', close: '\'' },
-	]
+	],
+	indentationRules: {
+		increaseIndentPattern: new RegExp('^\\s*((begin|class|(private|protected)\\s+def|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|([^#]*\\sdo\\b)|([^#]*=\\s*(case|if|unless)))\\b([^#\\{;]|("|\'|\/).*\\4)*(#.*)?$'),
+		decreaseIndentPattern: new RegExp('^\\s*([}\\]]([,)]?\\s*(#|$)|\\.[a-zA-Z_]\\w*\\b)|(end|rescue|ensure|else|elsif|when)\\b)'),
+	}
 };
 
 /*


### PR DESCRIPTION
Copied rules from `vscode/extensions/ruby/language-configuration.json`