### PR TITLE
allows annotation in markdown language block headers

### DIFF
--- a/src/markdown/markdown.ts
+++ b/src/markdown/markdown.ts
@@ -79,7 +79,7 @@ export const language = <ILanguage>{
 			[/^\s*~~~\s*((?:\w|[\/\-#])+)?\s*$/, { token: 'string', next: '@codeblock' }],
 
 			// github style code blocks (with backticks and language)
-			[/^\s*```\s*((?:\w|[\/\-#])+)\s*$/, { token: 'string', next: '@codeblockgh', nextEmbedded: '$1' }],
+			[/^\s*```\s*((?:\w|[\/\-#])+).*$/, { token: 'string', next: '@codeblockgh', nextEmbedded: '$1' }],
 
 			// github style code blocks (with backticks but no language)
 			[/^\s*```\s*$/, { token: 'string', next: '@codeblock' }],


### PR DESCRIPTION
Currently, syntax highlighting for code blocks in markdown files fails if you have anything after the language name other than whitespace.

example:
```
```python {annotation: test}
for x in y:
    x = 5
``` 

VSCode allows you to put annotation in code block headers, so this pull request fixes the syntax highlighting to match VSCode's behavior. The ability to add annotation is important for interactive computing tools like rmarkdown or imarkdown.