### PR TITLE
add `None` and `Some` keywords to SophiaML

### DIFF
--- a/src/sophia/sophia.ts
+++ b/src/sophia/sophia.ts
@@ -64,6 +64,8 @@ export const language = <ILanguage>{
 		'Address',
 		'Auth',
 		'Chain',
+		'None',
+		'Some',
 		'bits',
 		'bytes',
 		'event',


### PR DESCRIPTION
Adding `None` and `Some` keywords for SophiaML syntax.