### PR TITLE
add tokenizer for graphql language variables

### DIFF
--- a/src/graphql/graphql.test.ts
+++ b/src/graphql/graphql.test.ts
@@ -51,35 +51,35 @@ testTokenization('graphql', [
 		tokens: [
 			{ startIndex: 0, type: "keyword.gql" },                 // 'query'
 			{ startIndex: 5, type: "" },                            // ' '
-			{ startIndex: 6, type: "identifier.gql" },              // 'testQuery'
+			{ startIndex: 6, type: "key.identifier.gql" },              // 'testQuery'
 			{ startIndex: 15, type: "delimiter.parenthesis.gql" },  // '('
-			{ startIndex: 16, type: "identifier.gql" },             // '$intValue'
+			{ startIndex: 16, type: "argument.identifier.gql" },             // '$intValue'
 			{ startIndex: 25, type: "operator.gql" },               // ':'
 			{ startIndex: 26, type: "keyword.gql" },                // 'Int'
 			{ startIndex: 29, type: "operator.gql" },               // '='
 			{ startIndex: 30, type: "number.gql" },                 // '3'
 			{ startIndex: 31, type: "delimiter.parenthesis.gql" },  // ')'
 			{ startIndex: 32, type: "delimiter.curly.gql" },        // '{'
-			{ startIndex: 33, type: "identifier.gql" },             // 'value'
+			{ startIndex: 33, type: "key.identifier.gql" },             // 'value'
 			{ startIndex: 38, type: "delimiter.parenthesis.gql" },  // '('
-			{ startIndex: 39, type: "identifier.gql" },             // 'arg'
+			{ startIndex: 39, type: "key.identifier.gql" },             // 'arg'
 			{ startIndex: 42, type: "operator.gql" },               // ':'
 			{ startIndex: 43, type: "delimiter.curly.gql" },        // '{'
-			{ startIndex: 44, type: "identifier.gql" },             // 'string'
+			{ startIndex: 44, type: "key.identifier.gql" },             // 'string'
 			{ startIndex: 50, type: "operator.gql" },               // ':'
 			{ startIndex: 51, type: "string.quote.gql" },           // '"'
 			{ startIndex: 52, type: "string.gql" },                 // 'string'
 			{ startIndex: 58, type: "string.quote.gql" },           // '"'
 			{ startIndex: 59, type: "" },                           // ' '
-			{ startIndex: 60, type: "identifier.gql" },             // 'int'
+			{ startIndex: 60, type: "key.identifier.gql" },             // 'int'
 			{ startIndex: 63, type: "operator.gql" },               // ':'
-			{ startIndex: 64, type: "identifier.gql" },             // '$intValue'
+			{ startIndex: 64, type: "argument.identifier.gql" },             // '$intValue'
 			{ startIndex: 73, type: "delimiter.curly.gql" },        // '}'
 			{ startIndex: 74, type: "delimiter.parenthesis.gql" },  // ')'
 			{ startIndex: 75, type: "delimiter.curly.gql" },        // '{'
-			{ startIndex: 76, type: "identifier.gql" },             // 'field1'
+			{ startIndex: 76, type: "key.identifier.gql" },             // 'field1'
 			{ startIndex: 82, type: "" },                           // ' '
-			{ startIndex: 83, type: "identifier.gql" },             // 'field2'
+			{ startIndex: 83, type: "key.identifier.gql" },             // 'field2'
 			{ startIndex: 89, type: "delimiter.curly.gql" },        // '}}'
 		],
 	}],
@@ -125,7 +125,7 @@ testTokenization('graphql', [
 			line: '  id: ID!',
 			tokens: [
 				{ startIndex: 0, type: "" },
-				{ startIndex: 2, type: "identifier.gql" },
+				{ startIndex: 2, type: "key.identifier.gql" },
 				{ startIndex: 4, type: "operator.gql" },
 				{ startIndex: 5, type: "" },
 				{ startIndex: 6, type: "keyword.gql" },

--- a/src/graphql/graphql.ts
+++ b/src/graphql/graphql.ts
@@ -69,16 +69,30 @@ export const language = <ILanguage>{
 	// The main tokenizer for our languages
 	tokenizer: {
 		root: [
-			// identifiers and keywords
+
+			// fields and argument names
 			[
-				/[a-z_$][\w$]*/,
+				/[a-z_][\w$]*/,
 				{
 					cases: {
 						'@keywords': 'keyword',
-						'@default': 'identifier',
+						'@default': 'key.identifier',
 					},
 				},
 			],
+
+			// identify typed input variables
+			[
+				/[$][\w$]*/,
+				{
+					cases: {
+						'@keywords': 'keyword',
+						'@default': 'argument.identifier',
+					},
+				},
+			],
+
+			// to show class names nicely
 			[
 				/[A-Z][\w\$]*/,
 				{
@@ -87,7 +101,7 @@ export const language = <ILanguage>{
 						'@default': 'type.identifier',
 					},
 				},
-			], // to show class names nicely
+			],
 
 			// whitespace
 			{ include: '@whitespace' },


### PR DESCRIPTION
thought i would add a tokenizer that adds a bit more definition. let me know what you think of my useage of the identifiers? we basically have typed, named function parameters.

adding this for our upcoming custom `monaco-graphql`, and for other folks using monaco with graphql language.

the next PR I'll come up with will be to add a tokenizer that targets just the argument names (the names in the named parameters)

before:
![Screen Shot 2020-01-13 at 10 36 06 PM](https://user-images.githubusercontent.com/1368727/72312158-2b9c3900-3655-11ea-9432-a7fcc82046dc.png)

after:
![Screen Shot 2020-01-13 at 5 26 54 PM](https://user-images.githubusercontent.com/1368727/72310810-bf1f3b00-3650-11ea-935b-35f37e837bcd.png)


