### PR TITLE
Mocha, fix deprecation warning regarding mocha.opts

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "delay": true,
+  "ui": "tdd",
+  "spec": "test/all.js"
+}

--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,6 @@
 /tsconfig.json
 /.npmignore
 /.travis.yml
+/.mocharc.json
+/.editorconfig
+/azure-pipelines.yml

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,0 @@
---delay
---ui tdd
-test/all.js


### PR DESCRIPTION
This fixes the deprecation warning

> (node:3202) DeprecationWarning: Configuration via mocha.opts is DEPRECATED and will be removed from a future version of Mocha. Use RC files or package.json instead.

see
https://dev.azure.com/ms/monaco-languages/_build/results?buildId=65072&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=bd05475d-acb5-5619-3ccb-c46842dbc997&l=18

when running tests

**PLUS**: `.editorconfig` and `azure-pipelines.yml` are now npm ignored