### PR TITLE
VB: remove backslash as string literal escape character

### DIFF
--- a/src/vb/vb.ts
+++ b/src/vb/vb.ts
@@ -179,7 +179,7 @@ export const language = <ILanguage>{
 		],
 
 		string: [
-			[/[^\\"]+/, 'string'],
+			[/[^"]+/, 'string'],
 			[/@escapes/, 'string.escape'],
 			[/\\./, 'string.escape.invalid'],
 			[/"C?/, 'string', '@pop']


### PR DESCRIPTION
VB doesn't use as backslash as an escape character in string literals. 

As per language spec: https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/language-specification/lexical-grammar#string-literals

Lightly tested at https://microsoft.github.io/monaco-editor/monarch.html