### PR TITLE
Add support for Canarinho language

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "integrity": "sha512-d3mILzYSlsPEALCiDYkRnkiYN4cl62dkaCg00Uql/FShIvdMOBFGtjP0N/cm0aCXwaAPVBS5weD4ciHAD8RtsA==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "13.9.1"
       }
     },
     "abab": {
@@ -37,8 +37,8 @@
       "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.1",
-        "acorn-walk": "^7.1.1"
+        "acorn": "7.1.1",
+        "acorn-walk": "7.1.1"
       }
     },
     "acorn-walk": {
@@ -53,10 +53,10 @@
       "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "3.1.1",
+        "fast-json-stable-stringify": "2.1.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "asn1": {
@@ -65,7 +65,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "assert-plus": {
@@ -104,7 +104,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "brace-expansion": {
@@ -113,7 +113,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -141,7 +141,7 @@
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -174,7 +174,7 @@
       "integrity": "sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==",
       "dev": true,
       "requires": {
-        "cssom": "~0.3.6"
+        "cssom": "0.3.8"
       },
       "dependencies": {
         "cssom": {
@@ -191,7 +191,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "data-urls": {
@@ -200,9 +200,9 @@
       "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
       "dev": true,
       "requires": {
-        "abab": "^2.0.3",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^8.0.0"
+        "abab": "2.0.3",
+        "whatwg-mimetype": "2.3.0",
+        "whatwg-url": "8.0.0"
       }
     },
     "decimal.js": {
@@ -217,12 +217,12 @@
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
       "dev": true,
       "requires": {
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
+        "is-arguments": "1.0.4",
+        "is-date-object": "1.0.2",
+        "is-regex": "1.0.5",
+        "object-is": "1.0.2",
+        "object-keys": "1.1.1",
+        "regexp.prototype.flags": "1.3.0"
       }
     },
     "deep-is": {
@@ -237,7 +237,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "object-keys": "1.1.1"
       }
     },
     "defined": {
@@ -258,7 +258,7 @@
       "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
       "dev": true,
       "requires": {
-        "webidl-conversions": "^5.0.0"
+        "webidl-conversions": "5.0.0"
       }
     },
     "dotignore": {
@@ -267,7 +267,7 @@
       "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
       "dev": true,
       "requires": {
-        "minimatch": "^3.0.4"
+        "minimatch": "3.0.4"
       }
     },
     "ecc-jsbn": {
@@ -276,8 +276,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "es-abstract": {
@@ -286,17 +286,17 @@
       "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
-        "object-inspect": "^1.7.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "es-to-primitive": "1.2.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "has-symbols": "1.0.1",
+        "is-callable": "1.1.5",
+        "is-regex": "1.0.5",
+        "object-inspect": "1.7.0",
+        "object-keys": "1.1.1",
+        "object.assign": "4.1.0",
+        "string.prototype.trimleft": "2.1.1",
+        "string.prototype.trimright": "2.1.1"
       }
     },
     "es-to-primitive": {
@@ -305,9 +305,9 @@
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "1.1.5",
+        "is-date-object": "1.0.2",
+        "is-symbol": "1.0.3"
       }
     },
     "escodegen": {
@@ -316,11 +316,11 @@
       "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
       "dev": true,
       "requires": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "esprima": "4.0.1",
+        "estraverse": "4.3.0",
+        "esutils": "2.0.3",
+        "optionator": "0.8.3",
+        "source-map": "0.6.1"
       }
     },
     "esprima": {
@@ -377,7 +377,7 @@
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.3"
+        "is-callable": "1.1.5"
       }
     },
     "forever-agent": {
@@ -392,9 +392,9 @@
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.8",
+        "mime-types": "2.1.26"
       }
     },
     "fs.realpath": {
@@ -415,7 +415,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
@@ -424,12 +424,12 @@
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.4",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "har-schema": {
@@ -444,8 +444,8 @@
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
+        "ajv": "6.12.0",
+        "har-schema": "2.0.0"
       }
     },
     "has": {
@@ -454,7 +454,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-symbols": {
@@ -469,7 +469,7 @@
       "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "^1.0.5"
+        "whatwg-encoding": "1.0.5"
       }
     },
     "http-signature": {
@@ -478,9 +478,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.16.1"
       }
     },
     "iconv-lite": {
@@ -489,7 +489,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "inflight": {
@@ -498,8 +498,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -544,7 +544,7 @@
       "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "dev": true,
       "requires": {
-        "has": "^1.0.3"
+        "has": "1.0.3"
       }
     },
     "is-symbol": {
@@ -553,7 +553,7 @@
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.1"
+        "has-symbols": "1.0.1"
       }
     },
     "is-typedarray": {
@@ -580,32 +580,32 @@
       "integrity": "sha512-3p0gHs5EfT7PxW9v8Phz3mrq//4Dy8MQenU/PoKxhdT+c45S7NjIjKbGT3Ph0nkICweE1r36+yaknXA5WfVNAg==",
       "dev": true,
       "requires": {
-        "abab": "^2.0.3",
-        "acorn": "^7.1.1",
-        "acorn-globals": "^6.0.0",
-        "cssom": "^0.4.4",
-        "cssstyle": "^2.2.0",
-        "data-urls": "^2.0.0",
-        "decimal.js": "^10.2.0",
-        "domexception": "^2.0.1",
-        "escodegen": "^1.14.1",
-        "html-encoding-sniffer": "^2.0.1",
-        "is-potential-custom-element-name": "^1.0.0",
-        "nwsapi": "^2.2.0",
+        "abab": "2.0.3",
+        "acorn": "7.1.1",
+        "acorn-globals": "6.0.0",
+        "cssom": "0.4.4",
+        "cssstyle": "2.2.0",
+        "data-urls": "2.0.0",
+        "decimal.js": "10.2.0",
+        "domexception": "2.0.1",
+        "escodegen": "1.14.1",
+        "html-encoding-sniffer": "2.0.1",
+        "is-potential-custom-element-name": "1.0.0",
+        "nwsapi": "2.2.0",
         "parse5": "5.1.1",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.8",
-        "saxes": "^5.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^3.0.1",
-        "w3c-hr-time": "^1.0.2",
-        "w3c-xmlserializer": "^2.0.0",
-        "webidl-conversions": "^5.0.0",
-        "whatwg-encoding": "^1.0.5",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^8.0.0",
-        "ws": "^7.2.1",
-        "xml-name-validator": "^3.0.0"
+        "request": "2.88.2",
+        "request-promise-native": "1.0.8",
+        "saxes": "5.0.0",
+        "symbol-tree": "3.2.4",
+        "tough-cookie": "3.0.1",
+        "w3c-hr-time": "1.0.2",
+        "w3c-xmlserializer": "2.0.0",
+        "webidl-conversions": "5.0.0",
+        "whatwg-encoding": "1.0.5",
+        "whatwg-mimetype": "2.3.0",
+        "whatwg-url": "8.0.0",
+        "ws": "7.2.3",
+        "xml-name-validator": "3.0.0"
       }
     },
     "json-schema": {
@@ -644,8 +644,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "lodash": {
@@ -681,7 +681,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "monaco-editor-core": {
@@ -696,7 +696,7 @@
       "integrity": "sha512-7kUx8dtd5qVNVgUARBRhnM8oftPglYwlINfigC4yGUiuzqtIN22u1tly8umiOCIPR0eFiBLjt6aN23oZh2QJgg==",
       "dev": true,
       "requires": {
-        "typescript": "^2.7.2"
+        "typescript": "2.9.2"
       },
       "dependencies": {
         "typescript": {
@@ -743,10 +743,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.1",
+        "object-keys": "1.1.1"
       }
     },
     "once": {
@@ -755,7 +755,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "optionator": {
@@ -764,12 +764,12 @@
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "word-wrap": "1.2.3"
       }
     },
     "parse5": {
@@ -826,8 +826,8 @@
       "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.17.4"
       }
     },
     "request": {
@@ -836,26 +836,26 @@
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.9.1",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.8",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.3",
+        "har-validator": "5.1.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.26",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.2.0",
+        "tough-cookie": "2.5.0",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.4.0"
       },
       "dependencies": {
         "tough-cookie": {
@@ -864,8 +864,8 @@
           "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
           "dev": true,
           "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
+            "psl": "1.7.0",
+            "punycode": "2.1.1"
           }
         }
       }
@@ -876,7 +876,7 @@
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "4.17.15"
       }
     },
     "request-promise-native": {
@@ -886,8 +886,8 @@
       "dev": true,
       "requires": {
         "request-promise-core": "1.1.3",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.5.0"
       },
       "dependencies": {
         "tough-cookie": {
@@ -896,8 +896,8 @@
           "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
           "dev": true,
           "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
+            "psl": "1.7.0",
+            "punycode": "2.1.1"
           }
         }
       }
@@ -914,7 +914,7 @@
       "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.6"
+        "path-parse": "1.0.6"
       }
     },
     "resumer": {
@@ -923,7 +923,7 @@
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "dev": true,
       "requires": {
-        "through": "~2.3.4"
+        "through": "2.3.8"
       }
     },
     "safe-buffer": {
@@ -944,7 +944,7 @@
       "integrity": "sha512-LXTZygxhf8lfwKaTP/8N9CsVdjTlea3teze4lL6u37ivbgGbV0GGMuNtS/I9rnD/HC2/txUM7Df4S2LVl1qhiA==",
       "dev": true,
       "requires": {
-        "xmlchars": "^2.2.0"
+        "xmlchars": "2.2.0"
       }
     },
     "source-map": {
@@ -959,8 +959,8 @@
       "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
+        "buffer-from": "1.1.1",
+        "source-map": "0.6.1"
       }
     },
     "sshpk": {
@@ -969,15 +969,15 @@
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "stealthy-require": {
@@ -992,9 +992,9 @@
       "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "function-bind": "^1.1.1"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.17.4",
+        "function-bind": "1.1.1"
       }
     },
     "string.prototype.trimleft": {
@@ -1003,8 +1003,8 @@
       "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1"
       }
     },
     "string.prototype.trimright": {
@@ -1013,8 +1013,8 @@
       "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1"
       }
     },
     "symbol-tree": {
@@ -1029,21 +1029,21 @@
       "integrity": "sha512-waWwC/OqYVE9TS6r1IynlP2sEdk4Lfo6jazlgkuNkPTHIbuG2BTABIaKdlQWwPeB6Oo4ksZ1j33Yt0NTOAlYMQ==",
       "dev": true,
       "requires": {
-        "deep-equal": "~1.1.1",
-        "defined": "~1.0.0",
-        "dotignore": "~0.1.2",
-        "for-each": "~0.3.3",
-        "function-bind": "~1.1.1",
-        "glob": "~7.1.6",
-        "has": "~1.0.3",
-        "inherits": "~2.0.4",
-        "is-regex": "~1.0.5",
-        "minimist": "~1.2.0",
-        "object-inspect": "~1.7.0",
-        "resolve": "~1.15.1",
-        "resumer": "~0.0.0",
-        "string.prototype.trim": "~1.2.1",
-        "through": "~2.3.8"
+        "deep-equal": "1.1.1",
+        "defined": "1.0.0",
+        "dotignore": "0.1.2",
+        "for-each": "0.3.3",
+        "function-bind": "1.1.1",
+        "glob": "7.1.6",
+        "has": "1.0.3",
+        "inherits": "2.0.4",
+        "is-regex": "1.0.5",
+        "minimist": "1.2.5",
+        "object-inspect": "1.7.0",
+        "resolve": "1.15.1",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.2.1",
+        "through": "2.3.8"
       },
       "dependencies": {
         "minimist": {
@@ -1060,9 +1060,9 @@
       "integrity": "sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==",
       "dev": true,
       "requires": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
+        "commander": "2.20.3",
+        "source-map": "0.6.1",
+        "source-map-support": "0.5.16"
       }
     },
     "through": {
@@ -1077,9 +1077,9 @@
       "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
       "dev": true,
       "requires": {
-        "ip-regex": "^2.1.0",
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+        "ip-regex": "2.1.0",
+        "psl": "1.7.0",
+        "punycode": "2.1.1"
       }
     },
     "tr46": {
@@ -1088,7 +1088,7 @@
       "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.1"
+        "punycode": "2.1.1"
       }
     },
     "tunnel-agent": {
@@ -1097,7 +1097,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.2.0"
       }
     },
     "tweetnacl": {
@@ -1112,7 +1112,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "typescript": {
@@ -1127,7 +1127,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "uuid": {
@@ -1142,9 +1142,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "w3c-hr-time": {
@@ -1153,7 +1153,7 @@
       "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
       "dev": true,
       "requires": {
-        "browser-process-hrtime": "^1.0.0"
+        "browser-process-hrtime": "1.0.0"
       }
     },
     "w3c-xmlserializer": {
@@ -1162,7 +1162,7 @@
       "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
       "dev": true,
       "requires": {
-        "xml-name-validator": "^3.0.0"
+        "xml-name-validator": "3.0.0"
       }
     },
     "webidl-conversions": {
@@ -1192,9 +1192,9 @@
       "integrity": "sha512-41ou2Dugpij8/LPO5Pq64K5q++MnRCBpEHvQr26/mArEKTkCV5aoXIqyhuYtE0pkqScXwhf2JP57rkRTYM29lQ==",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^2.0.0",
-        "webidl-conversions": "^5.0.0"
+        "lodash.sortby": "4.7.0",
+        "tr46": "2.0.2",
+        "webidl-conversions": "5.0.0"
       }
     },
     "word-wrap": {

--- a/src/canarinho/canarinho.contribution.ts
+++ b/src/canarinho/canarinho.contribution.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import { registerLanguage } from '../_.contribution';
+
+registerLanguage({
+	id: 'canarinho',
+	extensions: ['.cnr'],
+	aliases: ['Canarinho', 'canarinho', 'cnr'],
+	mimetypes: ['text/canarinho'],
+	loader: () => import('./canarinho')
+});

--- a/src/canarinho/canarinho.test.ts
+++ b/src/canarinho/canarinho.test.ts
@@ -1,0 +1,772 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { testTokenization } from '../test/testRunner';
+
+testTokenization('canarinho', [
+	// Keywords
+	[{
+		// line: 'var x = function() { };',
+		line: 'variavel x = funcao() { };',
+		tokens: [
+			{ startIndex: 0, type: 'keyword.cnr' },
+			{ startIndex: 8, type: '' },
+			{ startIndex: 9, type: 'identifier.cnr' },
+			{ startIndex: 10, type: '' },
+			{ startIndex: 11, type: 'delimiter.cnr' },
+			{ startIndex: 12, type: '' },
+			{ startIndex: 13, type: 'keyword.cnr' },
+			{ startIndex: 19, type: 'delimiter.parenthesis.cnr' },
+			{ startIndex: 21, type: '' },
+			{ startIndex: 22, type: 'delimiter.bracket.cnr' },
+			{ startIndex: 23, type: '' },
+			{ startIndex: 24, type: 'delimiter.bracket.cnr' },
+			{ startIndex: 25, type: 'delimiter.cnr' }
+		]
+	}],
+
+	[{
+		line: '    variavel    ',
+		tokens: [
+			{ startIndex: 0, type: '' },
+			{ startIndex: 4, type: 'keyword.cnr' },
+			{ startIndex: 12, type: '' }
+		]
+	}],
+
+	// Comments - single line
+	[{
+		line: '//',
+		tokens: [
+			{ startIndex: 0, type: 'comment.cnr' }
+		]
+	}],
+
+	[{
+		line: '    // a comment',
+		tokens: [
+			{ startIndex: 0, type: '' },
+			{ startIndex: 4, type: 'comment.cnr' }
+		]
+	}],
+
+	[{
+		line: '// a comment',
+		tokens: [
+			{ startIndex: 0, type: 'comment.cnr' }
+		]
+	}],
+
+	[{
+		line: '// a comment /*',
+		tokens: [
+			{ startIndex: 0, type: 'comment.cnr' }
+		]
+	}],
+
+	[{
+		line: '// a comment /**',
+		tokens: [
+			{ startIndex: 0, type: 'comment.cnr' }
+		]
+	}],
+
+	[{
+		line: '//sticky comment',
+		tokens: [
+			{ startIndex: 0, type: 'comment.cnr' }
+		]
+	}],
+
+	[{
+		line: 'variavel x = 1; // my comment // is a nice one',
+		tokens: [
+			{ startIndex: 0, type: 'keyword.cnr' },
+			{ startIndex: 8, type: '' },
+			{ startIndex: 9, type: 'identifier.cnr' },
+			{ startIndex: 10, type: '' },
+			{ startIndex: 11, type: 'delimiter.cnr' },
+			{ startIndex: 12, type: '' },
+			{ startIndex: 13, type: 'number.cnr' },
+			{ startIndex: 14, type: 'delimiter.cnr' },
+			{ startIndex: 15, type: '' },
+			{ startIndex: 16, type: 'comment.cnr' }
+		]
+	}],
+
+	// Comments - range comment, single line
+	[{
+		line: '/* a simple comment */',
+		tokens: [
+			{ startIndex: 0, type: 'comment.cnr' }
+		]
+	}],
+
+	[{
+		line: 'variavel x = /* a simple comment */ 1;',
+		tokens: [
+			{ startIndex: 0, type: 'keyword.cnr' },
+			{ startIndex: 8, type: '' },
+			{ startIndex: 9, type: 'identifier.cnr' },
+			{ startIndex: 10, type: '' },
+			{ startIndex: 11, type: 'delimiter.cnr' },
+			{ startIndex: 12, type: '' },
+			{ startIndex: 13, type: 'comment.cnr' },
+			{ startIndex: 35, type: '' },
+			{ startIndex: 36, type: 'number.cnr' },
+			{ startIndex: 37, type: 'delimiter.cnr' }
+		]
+	}],
+
+	[{
+		line: 'x = /**/;',
+		tokens: [
+			{ startIndex: 0, type: 'identifier.cnr' },
+			{ startIndex: 1, type: '' },
+			{ startIndex: 2, type: 'delimiter.cnr' },
+			{ startIndex: 3, type: '' },
+			{ startIndex: 4, type: 'comment.cnr' },
+			{ startIndex: 8, type: 'delimiter.cnr' }
+		]
+	}],
+
+	[{
+		line: 'x = /*/;',
+		tokens: [
+			{ startIndex: 0, type: 'identifier.cnr' },
+			{ startIndex: 1, type: '' },
+			{ startIndex: 2, type: 'delimiter.cnr' },
+			{ startIndex: 3, type: '' },
+			{ startIndex: 4, type: 'comment.cnr' }
+		]
+	}],
+
+	// Comments - range comment, multi lines
+	[{
+		line: '/* a multiline comment',
+		tokens: [
+			{ startIndex: 0, type: 'comment.cnr' }
+		]
+	}, {
+		line: 'can actually span',
+		tokens: [
+			{ startIndex: 0, type: 'comment.cnr' }
+		]
+	}, {
+		line: 'multiple lines */',
+		tokens: [
+			{ startIndex: 0, type: 'comment.cnr' }
+		]
+	}],
+
+	[{
+		line: 'variavel x = /* start a comment',
+		tokens: [
+			{ startIndex: 0, type: 'keyword.cnr' },
+			{ startIndex: 8, type: '' },
+			{ startIndex: 9, type: 'identifier.cnr' },
+			{ startIndex: 10, type: '' },
+			{ startIndex: 11, type: 'delimiter.cnr' },
+			{ startIndex: 12, type: '' },
+			{ startIndex: 13, type: 'comment.cnr' }
+		]
+	}, {
+		line: ' a ',
+		tokens: [
+			{ startIndex: 0, type: 'comment.cnr' }
+		]
+	}, {
+		line: 'and end it */ variavel a = 2;',
+		tokens: [
+			{ startIndex: 0, type: 'comment.cnr' },
+			{ startIndex: 13, type: '' },
+			{ startIndex: 14, type: 'keyword.cnr' },
+			{ startIndex: 22, type: '' },
+			{ startIndex: 23, type: 'identifier.cnr' },
+			{ startIndex: 24, type: '' },
+			{ startIndex: 25, type: 'delimiter.cnr' },
+			{ startIndex: 26, type: '' },
+			{ startIndex: 27, type: 'number.cnr' },
+			{ startIndex: 28, type: 'delimiter.cnr' }
+		]
+	}],
+
+	// Strings
+	[{
+		line: 'variavel a = \'a\';',
+		tokens: [
+			{ startIndex: 0, type: 'keyword.cnr' },
+			{ startIndex: 8, type: '' },
+			{ startIndex: 9, type: 'identifier.cnr' },
+			{ startIndex: 10, type: '' },
+			{ startIndex: 11, type: 'delimiter.cnr' },
+			{ startIndex: 12, type: '' },
+			{ startIndex: 13, type: 'string.cnr' },
+			{ startIndex: 16, type: 'delimiter.cnr' }
+		]
+	}],
+
+	[{
+		line: 'b = a + " \'cool\'  "',
+		tokens: [
+			{ startIndex: 0, type: 'identifier.cnr' },
+			{ startIndex: 1, type: '' },
+			{ startIndex: 2, type: 'delimiter.cnr' },
+			{ startIndex: 3, type: '' },
+			{ startIndex: 4, type: 'identifier.cnr' },
+			{ startIndex: 5, type: '' },
+			{ startIndex: 6, type: 'delimiter.cnr' },
+			{ startIndex: 7, type: '' },
+			{ startIndex: 8, type: 'string.cnr' }
+		]
+	}],
+
+	[{
+		line: '"escaping \\"quotes\\" is cool"',
+		tokens: [
+			{ startIndex: 0, type: 'string.cnr' },
+			{ startIndex: 10, type: 'string.escape.cnr' },
+			{ startIndex: 12, type: 'string.cnr' },
+			{ startIndex: 18, type: 'string.escape.cnr' },
+			{ startIndex: 20, type: 'string.cnr' },
+		]
+	}],
+
+	[{
+		line: '\'\'\'',
+		tokens: [
+			{ startIndex: 0, type: 'string.cnr' },
+			{ startIndex: 2, type: 'string.invalid.cnr' },
+		]
+	}],
+
+	[{
+		line: '\'\\\'\'',
+		tokens: [
+			{ startIndex: 0, type: 'string.cnr' },
+			{ startIndex: 1, type: 'string.escape.cnr' },
+			{ startIndex: 3, type: 'string.cnr' },
+		]
+	}],
+
+	[{
+		line: '\'be careful \\not to escape\'',
+		tokens: [
+			{ startIndex: 0, type: 'string.cnr' },
+			{ startIndex: 12, type: 'string.escape.cnr' },
+			{ startIndex: 14, type: 'string.cnr' },
+		]
+	}],
+
+	// Numbers
+	[{
+		line: '0',
+		tokens: [
+			{ startIndex: 0, type: 'number.cnr' }
+		]
+	}],
+
+	[{
+		line: ' 0',
+		tokens: [
+			{ startIndex: 0, type: '' },
+			{ startIndex: 1, type: 'number.cnr' }
+		]
+	}],
+
+	[{
+		line: ' 0 ',
+		tokens: [
+			{ startIndex: 0, type: '' },
+			{ startIndex: 1, type: 'number.cnr' },
+			{ startIndex: 2, type: '' }
+		]
+	}],
+
+	[{
+		line: '0 ',
+		tokens: [
+			{ startIndex: 0, type: 'number.cnr' },
+			{ startIndex: 1, type: '' }
+		]
+	}],
+
+	[{
+		line: '0+0',
+		tokens: [
+			{ startIndex: 0, type: 'number.cnr' },
+			{ startIndex: 1, type: 'delimiter.cnr' },
+			{ startIndex: 2, type: 'number.cnr' }
+		]
+	}],
+
+	[{
+		line: '100+10',
+		tokens: [
+			{ startIndex: 0, type: 'number.cnr' },
+			{ startIndex: 3, type: 'delimiter.cnr' },
+			{ startIndex: 4, type: 'number.cnr' }
+		]
+	}],
+
+	[{
+		line: '0 + 0',
+		tokens: [
+			{ startIndex: 0, type: 'number.cnr' },
+			{ startIndex: 1, type: '' },
+			{ startIndex: 2, type: 'delimiter.cnr' },
+			{ startIndex: 3, type: '' },
+			{ startIndex: 4, type: 'number.cnr' }
+		]
+	}],
+
+	[{
+		line: '0123',
+		tokens: [
+			{ startIndex: 0, type: 'number.octal.cnr' }
+		]
+	}],
+
+	[{
+		line: '01239',
+		tokens: [
+			{ startIndex: 0, type: 'number.octal.cnr' },
+			{ startIndex: 4, type: 'number.cnr' }
+		]
+	}],
+
+	[{
+		line: '0o123',
+		tokens: [
+			{ startIndex: 0, type: 'number.octal.cnr' }
+		]
+	}],
+
+	[{
+		line: '0O123',
+		tokens: [
+			{ startIndex: 0, type: 'number.octal.cnr' }
+		]
+	}],
+
+	[{
+		line: '0x',
+		tokens: [
+			{ startIndex: 0, type: 'number.cnr' },
+			{ startIndex: 1, type: 'identifier.cnr' }
+		]
+	}],
+
+	[{
+		line: '0x123',
+		tokens: [
+			{ startIndex: 0, type: 'number.hex.cnr' }
+		]
+	}],
+
+	[{
+		line: '0X123',
+		tokens: [
+			{ startIndex: 0, type: 'number.hex.cnr' }
+		]
+	}],
+
+	[{
+		line: '0b101',
+		tokens: [
+			{ startIndex: 0, type: 'number.binary.cnr' }
+		]
+	}],
+
+	[{
+		line: '0B101',
+		tokens: [
+			{ startIndex: 0, type: 'number.binary.cnr' }
+		]
+	}],
+
+	// Bigint
+	[{
+		line: '0n',
+		tokens: [
+			{ startIndex: 0, type: 'number.cnr' }
+		]
+	}],
+
+	[{
+		line: ' 0n',
+		tokens: [
+			{ startIndex: 0, type: '' },
+			{ startIndex: 1, type: 'number.cnr' }
+		]
+	}],
+
+	[{
+		line: ' 0n ',
+		tokens: [
+			{ startIndex: 0, type: '' },
+			{ startIndex: 1, type: 'number.cnr' },
+			{ startIndex: 3, type: '' }
+		]
+	}],
+
+	[{
+		line: '0n ',
+		tokens: [
+			{ startIndex: 0, type: 'number.cnr' },
+			{ startIndex: 2, type: '' }
+		]
+	}],
+
+	[{
+		line: '0n+0n',
+		tokens: [
+			{ startIndex: 0, type: 'number.cnr' },
+			{ startIndex: 2, type: 'delimiter.cnr' },
+			{ startIndex: 3, type: 'number.cnr' }
+		]
+	}],
+
+	[{
+		line: '100n+10n',
+		tokens: [
+			{ startIndex: 0, type: 'number.cnr' },
+			{ startIndex: 4, type: 'delimiter.cnr' },
+			{ startIndex: 5, type: 'number.cnr' }
+		]
+	}],
+
+	[{
+		line: '0n + 0n',
+		tokens: [
+			{ startIndex: 0, type: 'number.cnr' },
+			{ startIndex: 2, type: '' },
+			{ startIndex: 3, type: 'delimiter.cnr' },
+			{ startIndex: 4, type: '' },
+			{ startIndex: 5, type: 'number.cnr' }
+		]
+	}],
+
+	[{
+		line: '0b101n',
+		tokens: [
+			{ startIndex: 0, type: 'number.binary.cnr' }
+		]
+	}],
+
+	[{
+		line: '0123n',
+		tokens: [
+			{ startIndex: 0, type: 'number.octal.cnr' }
+		]
+	}],
+
+	[{
+		line: '0o123n',
+		tokens: [
+			{ startIndex: 0, type: 'number.octal.cnr' }
+		]
+	}],
+
+	[{
+		line: '0x123n',
+		tokens: [
+			{ startIndex: 0, type: 'number.hex.cnr' }
+		]
+	}],
+
+	// Regular Expressions
+	[{
+		line: '//',
+		tokens: [
+			{ startIndex: 0, type: 'comment.cnr' }
+		]
+	}],
+
+	[{
+		line: '/**/',
+		tokens: [
+			{ startIndex: 0, type: 'comment.cnr' }
+		]
+	}],
+
+	[{
+		line: '/***/',
+		tokens: [
+			{ startIndex: 0, type: 'comment.doc.cnr' }
+		]
+	}],
+
+	[{
+		line: '5 / 3;',
+		tokens: [
+			{ startIndex: 0, type: 'number.cnr' },
+			{ startIndex: 1, type: '' },
+			{ startIndex: 2, type: 'delimiter.cnr' },
+			{ startIndex: 3, type: '' },
+			{ startIndex: 4, type: 'number.cnr' },
+			{ startIndex: 5, type: 'delimiter.cnr' }
+		]
+	}],
+
+	// Advanced regular expressions
+	[{
+		line: '1 / 2; /* comment',
+		tokens: [
+			{ startIndex: 0, type: 'number.cnr' },
+			{ startIndex: 1, type: '' },
+			{ startIndex: 2, type: 'delimiter.cnr' },
+			{ startIndex: 3, type: '' },
+			{ startIndex: 4, type: 'number.cnr' },
+			{ startIndex: 5, type: 'delimiter.cnr' },
+			{ startIndex: 6, type: '' },
+			{ startIndex: 7, type: 'comment.cnr' }
+		]
+	}],
+
+	[{
+		line: '1 / 2 / x / b;',
+		tokens: [
+			{ startIndex: 0, type: 'number.cnr' },
+			{ startIndex: 1, type: '' },
+			{ startIndex: 2, type: 'delimiter.cnr' },
+			{ startIndex: 3, type: '' },
+			{ startIndex: 4, type: 'number.cnr' },
+			{ startIndex: 5, type: '' },
+			{ startIndex: 6, type: 'delimiter.cnr' },
+			{ startIndex: 7, type: '' },
+			{ startIndex: 8, type: 'identifier.cnr' },
+			{ startIndex: 9, type: '' },
+			{ startIndex: 10, type: 'delimiter.cnr' },
+			{ startIndex: 11, type: '' },
+			{ startIndex: 12, type: 'identifier.cnr' },
+			{ startIndex: 13, type: 'delimiter.cnr' }
+		]
+	}],
+
+	[{
+		line: 'x = /foo/.test(\'\')',
+		tokens: [
+			{ startIndex: 0, type: 'identifier.cnr' },
+			{ startIndex: 1, type: '' },
+			{ startIndex: 2, type: 'delimiter.cnr' },
+			{ startIndex: 3, type: '' },
+			{ startIndex: 4, type: 'regexp.cnr' },
+			{ startIndex: 9, type: 'delimiter.cnr' },
+			{ startIndex: 10, type: 'identifier.cnr' },
+			{ startIndex: 14, type: 'delimiter.parenthesis.cnr' },
+			{ startIndex: 15, type: 'string.cnr' },
+			{ startIndex: 17, type: 'delimiter.parenthesis.cnr' }
+		]
+	}],
+
+	[{
+		line: '/foo/',
+		tokens: [
+			{ startIndex: 0, type: 'regexp.cnr' }
+		]
+	}],
+
+	[{
+		line: '/foo/g',
+		tokens: [
+			{ startIndex: 0, type: 'regexp.cnr' },
+			{ startIndex: 5, type: 'keyword.other.cnr' }
+		]
+	}],
+
+	[{
+		line: '/foo/gimsuy',
+		tokens: [
+			{ startIndex: 0, type: 'regexp.cnr' },
+			{ startIndex: 5, type: 'keyword.other.cnr' }
+		]
+	}],
+
+	[{
+		line: '/foo/q', // invalid flag
+		tokens: [
+			{ startIndex: 0, type: 'delimiter.cnr' },
+			{ startIndex: 1, type: 'identifier.cnr' },
+			{ startIndex: 4, type: 'delimiter.cnr' },
+			{ startIndex: 5, type: 'identifier.cnr' }
+		]
+	}],
+
+	[{
+		line: 'x = 1 + f(2 / 3, /foo/)',
+		tokens: [
+			{ startIndex: 0, type: 'identifier.cnr' },
+			{ startIndex: 1, type: '' },
+			{ startIndex: 2, type: 'delimiter.cnr' },
+			{ startIndex: 3, type: '' },
+			{ startIndex: 4, type: 'number.cnr' },
+			{ startIndex: 5, type: '' },
+			{ startIndex: 6, type: 'delimiter.cnr' },
+			{ startIndex: 7, type: '' },
+			{ startIndex: 8, type: 'identifier.cnr' },
+			{ startIndex: 9, type: 'delimiter.parenthesis.cnr' },
+			{ startIndex: 10, type: 'number.cnr' },
+			{ startIndex: 11, type: '' },
+			{ startIndex: 12, type: 'delimiter.cnr' },
+			{ startIndex: 13, type: '' },
+			{ startIndex: 14, type: 'number.cnr' },
+			{ startIndex: 15, type: 'delimiter.cnr' },
+			{ startIndex: 16, type: '' },
+			{ startIndex: 17, type: 'regexp.cnr' },
+			{ startIndex: 22, type: 'delimiter.parenthesis.cnr' }
+		]
+	}],
+
+	[{
+		line: 'a /ads/ b;',
+		tokens: [
+			{ startIndex: 0, type: 'identifier.cnr' },
+			{ startIndex: 1, type: '' },
+			{ startIndex: 2, type: 'delimiter.cnr' },
+			{ startIndex: 3, type: 'identifier.cnr' },
+			{ startIndex: 6, type: 'delimiter.cnr' },
+			{ startIndex: 7, type: '' },
+			{ startIndex: 8, type: 'identifier.cnr' },
+			{ startIndex: 9, type: 'delimiter.cnr' }
+		]
+	}],
+
+	[{
+		line: '1/(2/3)/2/3;',
+		tokens: [
+			{ startIndex: 0, type: 'number.cnr' },
+			{ startIndex: 1, type: 'delimiter.cnr' },
+			{ startIndex: 2, type: 'delimiter.parenthesis.cnr' },
+			{ startIndex: 3, type: 'number.cnr' },
+			{ startIndex: 4, type: 'delimiter.cnr' },
+			{ startIndex: 5, type: 'number.cnr' },
+			{ startIndex: 6, type: 'delimiter.parenthesis.cnr' },
+			{ startIndex: 7, type: 'delimiter.cnr' },
+			{ startIndex: 8, type: 'number.cnr' },
+			{ startIndex: 9, type: 'delimiter.cnr' },
+			{ startIndex: 10, type: 'number.cnr' },
+			{ startIndex: 11, type: 'delimiter.cnr' }
+		]
+	}],
+
+	[{
+		line: '{ key: 123 }',
+		tokens: [
+			{ startIndex: 0, type: 'delimiter.bracket.cnr' },
+			{ startIndex: 1, type: '' },
+			{ startIndex: 2, type: 'identifier.cnr' },
+			{ startIndex: 5, type: 'delimiter.cnr' },
+			{ startIndex: 6, type: '' },
+			{ startIndex: 7, type: 'number.cnr' },
+			{ startIndex: 10, type: '' },
+			{ startIndex: 11, type: 'delimiter.bracket.cnr' }
+		]
+	}],
+
+	[{
+		line: '[1,2,3]',
+		tokens: [
+			{ startIndex: 0, type: 'delimiter.square.cnr' },
+			{ startIndex: 1, type: 'number.cnr' },
+			{ startIndex: 2, type: 'delimiter.cnr' },
+			{ startIndex: 3, type: 'number.cnr' },
+			{ startIndex: 4, type: 'delimiter.cnr' },
+			{ startIndex: 5, type: 'number.cnr' },
+			{ startIndex: 6, type: 'delimiter.square.cnr' }
+		]
+	}],
+
+	[{
+		line: 'foo(123);',
+		tokens: [
+			{ startIndex: 0, type: 'identifier.cnr' },
+			{ startIndex: 3, type: 'delimiter.parenthesis.cnr' },
+			{ startIndex: 4, type: 'number.cnr' },
+			{ startIndex: 7, type: 'delimiter.parenthesis.cnr' },
+			{ startIndex: 8, type: 'delimiter.cnr' }
+		]
+	}],
+
+	[{
+		line: '{a:{b:[]}}',
+		tokens: [
+			{ startIndex: 0, type: 'delimiter.bracket.cnr' },
+			{ startIndex: 1, type: 'identifier.cnr' },
+			{ startIndex: 2, type: 'delimiter.cnr' },
+			{ startIndex: 3, type: 'delimiter.bracket.cnr' },
+			{ startIndex: 4, type: 'identifier.cnr' },
+			{ startIndex: 5, type: 'delimiter.cnr' },
+			{ startIndex: 6, type: 'delimiter.square.cnr' },
+			{ startIndex: 8, type: 'delimiter.bracket.cnr' }
+		]
+	}],
+
+	[{
+		line: 'x = "[{()}]"',
+		tokens: [
+			{ startIndex: 0, type: 'identifier.cnr' },
+			{ startIndex: 1, type: '' },
+			{ startIndex: 2, type: 'delimiter.cnr' },
+			{ startIndex: 3, type: '' },
+			{ startIndex: 4, type: 'string.cnr' }
+		]
+	}],
+
+
+	[{
+		line: 'test ? 1 : 2',
+		tokens: [
+			{ startIndex: 0, type: 'identifier.cnr' },
+			{ startIndex: 4, type: '' },
+			{ startIndex: 5, type: 'delimiter.cnr' },
+			{ startIndex: 6, type: '' },
+			{ startIndex: 7, type: 'number.cnr' },
+			{ startIndex: 8, type: '' },
+			{ startIndex: 9, type: 'delimiter.cnr' },
+			{ startIndex: 10, type: '' },
+			{ startIndex: 11, type: 'number.cnr' },
+		]
+	}],
+
+	[{
+		line: 'couldBeNullish ?? 1',
+		tokens: [
+			{ startIndex: 0, type: 'identifier.cnr' },
+			{ startIndex: 14, type: '' },
+			{ startIndex: 15, type: 'delimiter.cnr' },
+			{ startIndex: 17, type: '' },
+			{ startIndex: 18, type: 'number.cnr' }
+		]
+	}],
+
+
+	[{
+		line: '`${5 + \'x\' + 3}a${4}`',
+		tokens: [
+			{ startIndex: 0, type: 'string.cnr' },
+			{ startIndex: 1, type: 'delimiter.bracket.cnr' },
+			{ startIndex: 3, type: 'number.cnr' },
+			{ startIndex: 4, type: '' },
+			{ startIndex: 5, type: 'delimiter.cnr' },
+			{ startIndex: 6, type: '' },
+			{ startIndex: 7, type: 'string.cnr' },
+			{ startIndex: 10, type: '' },
+			{ startIndex: 11, type: 'delimiter.cnr' },
+			{ startIndex: 12, type: '' },
+			{ startIndex: 13, type: 'number.cnr' },
+			{ startIndex: 14, type: 'delimiter.bracket.cnr' },
+			{ startIndex: 15, type: 'string.cnr' },
+			{ startIndex: 16, type: 'delimiter.bracket.cnr' },
+			{ startIndex: 18, type: 'number.cnr' },
+			{ startIndex: 19, type: 'delimiter.bracket.cnr' },
+			{ startIndex: 20, type: 'string.cnr' },
+
+		]
+	}]
+
+]);

--- a/src/canarinho/canarinho.ts
+++ b/src/canarinho/canarinho.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { conf as tsConf, language as tsLanguage } from '../typescript/typescript';
+import IRichLanguageConfiguration = monaco.languages.LanguageConfiguration;
+import ILanguage = monaco.languages.IMonarchLanguage;
+
+// Allow for running under nodejs/requirejs in tests
+const _monaco: typeof monaco = (typeof monaco === 'undefined' ? (<any>self).monaco : monaco);
+
+export const conf: IRichLanguageConfiguration = tsConf;
+
+export const language = <ILanguage>{
+	// Set defaultToken to invalid to see what you do not tokenize yet
+	defaultToken: 'invalid',
+	tokenPostfix: '.cnr',
+
+	keywords: [
+		"caso seja", "classe", "construtor",
+		"em caso inesperado", "em_maiusculo", "em_minusculo", "enquanto",
+		"falso", "funcao", "imprimir", "importar", "instanciar", "instancia",
+		"metodo", "nulo", "ou entao", "parar", "retornar",
+		"se", "senao", "variavel", "verdadeiro", "verificar",
+	],
+	typeKeywords: [],
+
+	operators: tsLanguage.operators,
+	symbols: tsLanguage.symbols,
+	escapes: tsLanguage.escapes,
+	digits: tsLanguage.digits,
+	octaldigits: tsLanguage.octaldigits,
+	binarydigits: tsLanguage.binarydigits,
+	hexdigits: tsLanguage.hexdigits,
+	regexpctl: tsLanguage.regexpctl,
+	regexpesc: tsLanguage.regexpesc,
+	tokenizer: tsLanguage.tokenizer,
+};

--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -9,6 +9,7 @@ import './apex/apex.contribution';
 import './azcli/azcli.contribution';
 import './bat/bat.contribution';
 import './cameligo/cameligo.contribution';
+import './canarinho/canarinho.contribution';
 import './clojure/clojure.contribution';
 import './coffee/coffee.contribution';
 import './cpp/cpp.contribution';


### PR DESCRIPTION
Canarinho is an open-source programming language for portuguese speakers, built on top of JavaScript. Check out [canarinho-js/canarinho](https://github.com/canarinho-js/canarinho) for more details.

We need its syntax to be highlighted on `monaco-editor` because we are using it in an online playground made for people interested in trying it out.

In order to achieve that, this PR introduces 3 new files (highly inspired by `src/javascript/` content):

- `src/canarinho/canarinho.contribution.ts`
- `src/canarinho/canarinho.test.ts`
- `src/canarinho/canarinho.ts`

And modifies `src/monaco.contribution.ts` accordingly.

Could you take a look on the changes and help me merging/publishing it?

Thank you 😉 