### PR TITLE
terraform Fix heredoc

### DIFF
--- a/src/hcl/hcl.test.ts
+++ b/src/hcl/hcl.test.ts
@@ -992,6 +992,35 @@ testTokenization('hcl', [
 		}
 	],
 	/*
+      foo = <<-EOF
+      bar
+      EOF
+    */
+	[
+		{
+			line: '  foo = <<-EOF',
+			tokens: [
+				{ startIndex: 0, type: '' },
+				{ startIndex: 2, type: 'variable.hcl' },
+				{ startIndex: 5, type: '' },
+				{ startIndex: 6, type: 'operator.hcl' },
+				{ startIndex: 7, type: '' },
+				{ startIndex: 8, type: 'string.heredoc.delimiter.hcl' }
+			]
+		},
+		{
+			line: '  bar',
+			tokens: [{ startIndex: 0, type: 'string.heredoc.hcl' }]
+		},
+		{
+			line: '  EOF',
+			tokens: [
+				{ startIndex: 0, type: 'string.heredoc.hcl' },
+				{ startIndex: 2, type: 'string.heredoc.delimiter.hcl' }
+			]
+		}
+	],
+	/*
     foo = <<EOF
     bar
     EOF

--- a/src/hcl/hcl.ts
+++ b/src/hcl/hcl.ts
@@ -143,7 +143,7 @@ export const language = <languages.IMonarchLanguage>{
 		],
 		heredocBody: [
 			[
-				/^([\w\-]+)$/,
+				/([\w\-]+)$/,
 				{
 					cases: {
 						'$1==$S2': [


### PR DESCRIPTION
This fixes a bug when spaces are added before the heredoc termination


```
  command = <<-EOF
      string
EOF
```

was working

```
  command = <<-EOF
      string
    EOF
```

was not and it should
