### PR TITLE
Property is not a keyword in C#

### DIFF
--- a/src/csharp/csharp.ts
+++ b/src/csharp/csharp.ts
@@ -125,7 +125,6 @@ export const language = <languages.IMonarchLanguage>{
 		'event',
 		'method',
 		'param',
-		'property',
 		'public',
 		'protected',
 		'internal',


### PR DESCRIPTION
Please see C# language specification: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/introduction