### PR TITLE
Add hbs alias to handlebars

### DIFF
--- a/src/handlebars/handlebars.contribution.ts
+++ b/src/handlebars/handlebars.contribution.ts
@@ -8,7 +8,7 @@ import { registerLanguage } from '../_.contribution';
 registerLanguage({
 	id: 'handlebars',
 	extensions: ['.handlebars', '.hbs'],
-	aliases: ['Handlebars', 'handlebars'],
+	aliases: ['Handlebars', 'handlebars', 'hbs'],
 	mimetypes: ['text/x-handlebars-template'],
 	loader: () => import('./handlebars')
 });


### PR DESCRIPTION
handlebars in markdown is often abbreviate as `hbs`.

This change will hopefully enable monaco to have `hbs` highlighting in markdown