### PR TITLE
Fix incorrect filenames for liquid

### DIFF
--- a/src/liquid/liquid.contribution.ts
+++ b/src/liquid/liquid.contribution.ts
@@ -7,6 +7,6 @@ import { registerLanguage } from '../_.contribution';
 
 registerLanguage({
 	id: 'liquid',
-	extensions: ['.liquid', '.liquid.html', '.liquid.css'],
+	extensions: ['.liquid', '.html.liquid'],
 	loader: () => import('./liquid')
 });


### PR DESCRIPTION
Turns out the convention is to have .liquid after .html. Also, I didn't implement liquid with CSS so removed that