### PR TITLE
Add aliases and mimetypes to liquid language

### DIFF
--- a/src/liquid/liquid.contribution.ts
+++ b/src/liquid/liquid.contribution.ts
@@ -8,5 +8,7 @@ import { registerLanguage } from '../_.contribution';
 registerLanguage({
 	id: 'liquid',
 	extensions: ['.liquid', '.liquid.html', '.liquid.css'],
+	aliases: ['Liquid', 'liquid'],
+	mimetypes: ['application/liquid'],
 	loader: () => import('./liquid')
 });


### PR DESCRIPTION
liquid should be findable using `Liquid` or `liquid` as the language.