### PR TITLE
[TS] Add override keyword

### DIFF
--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -130,6 +130,7 @@ export const language = {
 		'private',
 		'protected',
 		'public',
+		'override',
 		'readonly',
 		'require',
 		'global',


### PR DESCRIPTION
TypeScript 4.3 defines a new keyword `override`. Feel free to wait with the merge until https://github.com/microsoft/monaco-typescript/ is on 4.3.