### PR TITLE
improve a rule which freeze a page in restructuredText

### DIFF
--- a/src/restructuredtext/restructuredtext.test.ts
+++ b/src/restructuredtext/restructuredtext.test.ts
@@ -8,6 +8,12 @@ import { testTokenization } from '../test/testRunner';
 testTokenization('restructuredtext', [
 	[
 		{
+			line: 'some property = Text::ProxyLibrary::ProxyInterfaceTest::DeleteProxyInterface();',
+			tokens: [{ startIndex: 0, type: '' }]
+		}
+	],
+	[
+		{
 			line: '#####',
 			tokens: [{ startIndex: 0, type: 'keyword.rst' }]
 		}

--- a/src/restructuredtext/restructuredtext.ts
+++ b/src/restructuredtext/restructuredtext.ts
@@ -54,10 +54,9 @@ export const language = <languages.IMonarchLanguage>{
 	],
 
 	alphanumerics: /[A-Za-z0-9]/,
-	alphanumericsplus: /[A-Za-z0-9-_+:.]/,
-	simpleRefNameWithoutBq: /(?:@alphanumerics@alphanumericsplus*@alphanumerics)+|(?:@alphanumerics+)/,
-	simpleRefName: /(?:`@simpleRefNameWithoutBq`|@simpleRefNameWithoutBq)/,
-	phrase: /@simpleRefName(?:\s@simpleRefName)*/,
+	simpleRefNameWithoutBq: /(?:@alphanumerics[-_+:.]*@alphanumerics)+|(?:@alphanumerics+)/,
+	simpleRefName: /(?:`@phrase`|@simpleRefNameWithoutBq)/,
+	phrase: /@simpleRefNameWithoutBq(?:\s@simpleRefNameWithoutBq)*/,
 	citationName: /[A-Za-z][A-Za-z0-9-_.]*/,
 	blockLiteralStart: /(?:[!"#$%&'()*+,-./:;<=>?@\[\]^_`{|}~]|[\s])/,
 	precedingChars: /(?:[ -:/'"<([{])/,


### PR DESCRIPTION
It fixes microsoft/monaco-editor#2484. There was a bad rule to freeze the page. 

A new case is added to test `some property = Text::ProxyLibrary::ProxyInterfaceTest::DeleteProxyInterface();`