### PR TITLE
fix c++ comment continuation highlighting #2497

### DIFF
--- a/src/cpp/cpp.test.ts
+++ b/src/cpp/cpp.test.ts
@@ -950,5 +950,30 @@ testTokenization('cpp', [
 				{ startIndex: 22, type: 'keyword.directive.include.end.cpp' }
 			]
 		}
+	],
+
+	[
+		// microsoft/monaco-editor#2497 : comment continuation highlighting
+		{
+			line: '// this is a comment \\',
+			tokens: [{ startIndex: 0, type: 'comment.cpp' }]
+		},
+		{
+			line: 'this is still a comment',
+			tokens: [{ startIndex: 0, type: 'comment.cpp' }]
+		},
+		{
+			line: 'int x = 1;',
+			tokens: [
+				{ startIndex: 0, type: 'keyword.int.cpp' },
+				{ startIndex: 3, type: '' },
+				{ startIndex: 4, type: 'identifier.cpp' },
+				{ startIndex: 5, type: '' },
+				{ startIndex: 6, type: 'delimiter.cpp' },
+				{ startIndex: 7, type: '' },
+				{ startIndex: 8, type: 'number.cpp' },
+				{ startIndex: 9, type: 'delimiter.cpp' }
+			]
+		}
 	]
 ]);

--- a/src/cpp/cpp.ts
+++ b/src/cpp/cpp.ts
@@ -347,10 +347,12 @@ export const language = <languages.IMonarchLanguage>{
 			[/[ \t\r\n]+/, ''],
 			[/\/\*\*(?!\/)/, 'comment.doc', '@doccomment'],
 			[/\/\*/, 'comment', '@comment'],
+			[/\/\/.*\\$/, 'comment', '@comment'],
 			[/\/\/.*$/, 'comment']
 		],
 
 		comment: [
+			[/.*[^\\]$/, 'comment', '@pop'],
 			[/[^\/*]+/, 'comment'],
 			[/\*\//, 'comment', '@pop'],
 			[/[\/*]/, 'comment']

--- a/src/cpp/cpp.ts
+++ b/src/cpp/cpp.ts
@@ -347,16 +347,22 @@ export const language = <languages.IMonarchLanguage>{
 			[/[ \t\r\n]+/, ''],
 			[/\/\*\*(?!\/)/, 'comment.doc', '@doccomment'],
 			[/\/\*/, 'comment', '@comment'],
-			[/\/\/.*\\$/, 'comment', '@comment'],
+			[/\/\/.*\\$/, 'comment', '@linecomment'],
 			[/\/\/.*$/, 'comment']
 		],
 
 		comment: [
-			[/.*[^\\]$/, 'comment', '@pop'],
 			[/[^\/*]+/, 'comment'],
 			[/\*\//, 'comment', '@pop'],
 			[/[\/*]/, 'comment']
 		],
+		
+		//For use with continuous line comments
+		linecomment: [
+			[/.*[^\\]$/, 'comment', '@pop'],
+			[/[^]+/, 'comment']
+		],
+		
 		//Identical copy of comment above, except for the addition of .doc
 		doccomment: [
 			[/[^\/*]+/, 'comment.doc'],


### PR DESCRIPTION
This PR fixes an issue where c++ continuation comment syntax was not highlighted as a comment.

```c++
// test \
test \
test

```

[https://github.com/microsoft/monaco-editor/issues/2497](https://github.com/microsoft/monaco-editor/issues/2497)