### PR TITLE
Add Swift fileprivate access modifier

### DIFF
--- a/src/swift/swift.ts
+++ b/src/swift/swift.ts
@@ -55,7 +55,7 @@ export const language = <languages.IMonarchLanguage>{
 		'@IBInspectable',
 		'@IBOutlet'
 	],
-	accessmodifiers: ['public', 'private', 'internal'],
+	accessmodifiers: ['public', 'private', 'fileprivate', 'internal'],
 	keywords: [
 		'__COLUMN__',
 		'__FILE__',

--- a/src/swift/swift.ts
+++ b/src/swift/swift.ts
@@ -81,6 +81,7 @@ export const language = <languages.IMonarchLanguage>{
 		'enum',
 		'extension',
 		'fallthrough',
+		'fileprivate',
 		'final',
 		'for',
 		'func',


### PR DESCRIPTION
As per https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html#ID5, this PR adds the missing fileprivate access modifier to the Swift definition

This should close https://github.com/microsoft/monaco-editor/issues/2560