### PR TITLE
fix rust raw string highlighting #2552

### DIFF
--- a/src/rust/rust.test.ts
+++ b/src/rust/rust.test.ts
@@ -23,6 +23,44 @@ testTokenization('rust', [
 			]
 		}
 	],
+	// Raw String
+	[
+		{
+			line: 'r"This is a raw string" ',
+			tokens: [
+				{ startIndex: 0, type: 'string.raw.rust' },
+				{ startIndex: 23, type: 'white.rust' },
+			]
+		}
+	],
+	[
+		{
+			line: 'r#"This is a raw string"# ',
+			tokens: [
+				{ startIndex: 0, type: 'string.raw.rust' },
+				{ startIndex: 25, type: 'white.rust' },
+			]
+		}
+	],
+	[
+		{
+			line: 'r##"This is a# raw string"## ',
+			tokens: [
+				{ startIndex: 0, type: 'string.raw.rust' },
+				{ startIndex: 28, type: 'white.rust' },
+			]
+		}
+	],
+	[
+		{
+			line: 'r###"This is ##"#"##a raw### string"### ',
+			tokens: [
+				{ startIndex: 0, type: 'string.raw.rust' },
+				{ startIndex: 39, type: 'white.rust' },
+			]
+		}
+	],
+	
 	// Byte literal
 	[
 		{

--- a/src/rust/rust.ts
+++ b/src/rust/rust.ts
@@ -270,6 +270,8 @@ export const language = <languages.IMonarchLanguage>{
 
 	tokenizer: {
 		root: [
+			// Raw string literals
+			[/r(?=#*")/, { token: 'string.raw', bracket: '@open', next: '@stringraw' }],
 			[
 				/[a-zA-Z][a-zA-Z0-9_]*!?|_[a-zA-Z0-9_]+/,
 				{
@@ -326,6 +328,10 @@ export const language = <languages.IMonarchLanguage>{
 			[/@escapes/, 'string.escape'],
 			[/\\./, 'string.escape.invalid'],
 			[/"/, { token: 'string.quote', bracket: '@close', next: '@pop' }]
+		],
+		stringraw: [
+				[/[^#"]/, 'string.raw'],
+				[/(#*)".*?"\1/, { token: 'string.raw', bracket: '@close', next: '@pop' }]
 		],
 		numbers: [
 			//Octal

--- a/src/rust/rust.ts
+++ b/src/rust/rust.ts
@@ -290,7 +290,7 @@ export const language = <languages.IMonarchLanguage>{
 			// Lifetime annotations
 			[/'[a-zA-Z_][a-zA-Z0-9_]*(?=[^\'])/, 'identifier'],
 			// Byte literal
-			[/'(\S)'/, 'string.byteliteral'],
+			[/'\S'/, 'string.byteliteral'],
 			// Strings
 			[/"/, { token: 'string.quote', bracket: '@open', next: '@string' }],
 			{ include: '@numbers' },

--- a/src/rust/rust.ts
+++ b/src/rust/rust.ts
@@ -290,7 +290,7 @@ export const language = <languages.IMonarchLanguage>{
 			// Lifetime annotations
 			[/'[a-zA-Z_][a-zA-Z0-9_]*(?=[^\'])/, 'identifier'],
 			// Byte literal
-			[/'(\S|@escapes)'/, 'string.byteliteral'],
+			[/'(\S)'/, 'string.byteliteral'],
 			// Strings
 			[/"/, { token: 'string.quote', bracket: '@open', next: '@string' }],
 			{ include: '@numbers' },

--- a/src/rust/rust.ts
+++ b/src/rust/rust.ts
@@ -290,7 +290,7 @@ export const language = <languages.IMonarchLanguage>{
 			// Lifetime annotations
 			[/'[a-zA-Z_][a-zA-Z0-9_]*(?=[^\'])/, 'identifier'],
 			// Byte literal
-			[/'\S'/, 'string.byteliteral'],
+			[/'(\S|@escapes)'/, 'string.byteliteral'],
 			// Strings
 			[/"/, { token: 'string.quote', bracket: '@open', next: '@string' }],
 			{ include: '@numbers' },


### PR DESCRIPTION
This PR fixes an issue where rust raw strings were not highlighted

```rust
r"\"
r##"now#"#"highlighted"##
```

https://github.com/microsoft/monaco-editor/issues/2552