### PR TITLE
fix char literal highlighting #2481

### DIFF
--- a/src/rust/rust.test.ts
+++ b/src/rust/rust.test.ts
@@ -38,7 +38,19 @@ testTokenization('rust', [
 			]
 		}
 	],
-
+	[
+		{
+			line: "'\"'",
+			tokens: [{ startIndex: 0, type: 'string.byteliteral.rust' }]
+		}
+	],
+	[
+		{
+			line: "'\0'",
+			tokens: [{ startIndex: 0, type: 'string.byteliteral.rust' }]
+		}
+	],
+	
 	// Comment
 	[
 		{

--- a/src/rust/rust.ts
+++ b/src/rust/rust.ts
@@ -270,8 +270,6 @@ export const language = <languages.IMonarchLanguage>{
 
 	tokenizer: {
 		root: [
-			// Raw string literals
-			[/r(?=#*")/, { token: 'string.raw', bracket: '@open', next: '@stringraw' }],
 			[
 				/[a-zA-Z][a-zA-Z0-9_]*!?|_[a-zA-Z0-9_]+/,
 				{
@@ -328,10 +326,6 @@ export const language = <languages.IMonarchLanguage>{
 			[/@escapes/, 'string.escape'],
 			[/\\./, 'string.escape.invalid'],
 			[/"/, { token: 'string.quote', bracket: '@close', next: '@pop' }]
-		],
-		stringraw: [
-				[/[^#"]/, 'string.raw'],
-				[/(#*)".*?"\1/, { token: 'string.raw', bracket: '@close', next: '@pop' }]
 		],
 		numbers: [
 			//Octal

--- a/src/rust/rust.ts
+++ b/src/rust/rust.ts
@@ -270,6 +270,8 @@ export const language = <languages.IMonarchLanguage>{
 
 	tokenizer: {
 		root: [
+			// Raw string literals
+			[/r(?=#*")/, { token: 'string.raw', bracket: '@open', next: '@stringraw' }],
 			[
 				/[a-zA-Z][a-zA-Z0-9_]*!?|_[a-zA-Z0-9_]+/,
 				{
@@ -326,6 +328,10 @@ export const language = <languages.IMonarchLanguage>{
 			[/@escapes/, 'string.escape'],
 			[/\\./, 'string.escape.invalid'],
 			[/"/, { token: 'string.quote', bracket: '@close', next: '@pop' }]
+		],
+		stringraw: [
+				[/[^#"]/, 'string.raw'],
+				[/(#*)".*?"\1/, { token: 'string.raw', bracket: '@close', next: '@pop' }]
 		],
 		numbers: [
 			//Octal

--- a/src/rust/rust.ts
+++ b/src/rust/rust.ts
@@ -290,7 +290,7 @@ export const language = <languages.IMonarchLanguage>{
 			// Lifetime annotations
 			[/'[a-zA-Z_][a-zA-Z0-9_]*(?=[^\'])/, 'identifier'],
 			// Byte literal
-			[/'\S'/, 'string.byteliteral'],
+			[/'(\S|@escapes)'/, 'string.byteliteral'],
 			// Strings
 			[/"/, { token: 'string.quote', bracket: '@open', next: '@string' }],
 			{ include: '@numbers' },


### PR DESCRIPTION
This PR fixes an issue where char literal were not highlighting when using escape sequences

```rust
'"'
 #'\n'
```

https://github.com/microsoft/monaco-editor/issues/2481