### PR TITLE
Properly tokenize fence closing in GitHub style code blocks

### DIFF
--- a/src/markdown/markdown.ts
+++ b/src/markdown/markdown.ts
@@ -135,7 +135,7 @@ export const language = <languages.IMonarchLanguage>{
 
 		// github style code blocks
 		codeblockgh: [
-			[/```\s*$/, { token: 'variable.source', next: '@pop', nextEmbedded: '@pop' }],
+			[/```\s*$/, { token: 'string', next: '@pop', nextEmbedded: '@pop' }],
 			[/[^`]+/, 'variable.source']
 		],
 


### PR DESCRIPTION
Currently Markdown tokenizer marks both opening and closing <code>\`\`\`</code> as `string`. However, if the opening one includes language as in <code>\`\`\`elixir</code>, then the closing one is incorrectly tokenized as `variable.source`.