### PR TITLE
Fix razor + liquid render of tags with a dash symbol

### DIFF
--- a/src/liquid/liquid.ts
+++ b/src/liquid/liquid.ts
@@ -167,9 +167,9 @@ export const language = <languages.IMonarchLanguage>{
 			[/\{\%\s*comment\s*\%\}/, 'comment.start.liquid', '@comment'],
 			[/\{\{/, { token: '@rematch', switchTo: '@liquidState.root' }],
 			[/\{\%/, { token: '@rematch', switchTo: '@liquidState.root' }],
-			[/(<)(\w+)(\/>)/, ['delimiter.html', 'tag.html', 'delimiter.html']],
+			[/(<)([\w\-]+)(\/>)/, ['delimiter.html', 'tag.html', 'delimiter.html']],
 			[/(<)([:\w]+)/, ['delimiter.html', { token: 'tag.html', next: '@otherTag' }]],
-			[/(<\/)(\w+)/, ['delimiter.html', { token: 'tag.html', next: '@otherTag' }]],
+			[/(<\/)([\w\-]+)/, ['delimiter.html', { token: 'tag.html', next: '@otherTag' }]],
 			[/</, 'delimiter.html'],
 			[/\{/, 'delimiter.html'],
 			[/[^<{]+/] // text

--- a/src/razor/razor.ts
+++ b/src/razor/razor.ts
@@ -85,11 +85,11 @@ export const language = <languages.IMonarchLanguage>{
 			[/@[^@]/, { token: '@rematch', switchTo: '@razorInSimpleState.root' }],
 			[/<!DOCTYPE/, 'metatag.html', '@doctype'],
 			[/<!--/, 'comment.html', '@comment'],
-			[/(<)(\w+)(\/>)/, ['delimiter.html', 'tag.html', 'delimiter.html']],
+			[/(<)([\w\-]+)(\/>)/, ['delimiter.html', 'tag.html', 'delimiter.html']],
 			[/(<)(script)/, ['delimiter.html', { token: 'tag.html', next: '@script' }]],
 			[/(<)(style)/, ['delimiter.html', { token: 'tag.html', next: '@style' }]],
-			[/(<)([:\w]+)/, ['delimiter.html', { token: 'tag.html', next: '@otherTag' }]],
-			[/(<\/)(\w+)/, ['delimiter.html', { token: 'tag.html', next: '@otherTag' }]],
+			[/(<)([:\w\-]+)/, ['delimiter.html', { token: 'tag.html', next: '@otherTag' }]],
+			[/(<\/)([\w\-]+)/, ['delimiter.html', { token: 'tag.html', next: '@otherTag' }]],
 			[/</, 'delimiter.html'],
 			[/[ \t\r\n]+/], // whitespace
 			[/[^<@]+/] // text
@@ -453,9 +453,9 @@ export const language = <languages.IMonarchLanguage>{
 			[/'([^']*)'/, 'string.cs'],
 
 			// simple html
-			[/(<)(\w+)(\/>)/, ['delimiter.html', 'tag.html', 'delimiter.html']],
-			[/(<)(\w+)(>)/, ['delimiter.html', 'tag.html', 'delimiter.html']],
-			[/(<\/)(\w+)(>)/, ['delimiter.html', 'tag.html', 'delimiter.html']],
+			[/(<)([\w\-]+)(\/>)/, ['delimiter.html', 'tag.html', 'delimiter.html']],
+			[/(<)([\w\-]+)(>)/, ['delimiter.html', 'tag.html', 'delimiter.html']],
+			[/(<\/)([\w\-]+)(>)/, ['delimiter.html', 'tag.html', 'delimiter.html']],
 
 			// delimiters
 			[/[\+\-\*\%\&\|\^\~\!\=\<\>\/\?\;\:\.\,]/, 'delimiter.cs'],


### PR DESCRIPTION
This PR fixes rendering of html tags with a `-` symbol (custom elements in w3c spec.) in razor & liquid. Custom tags are already rendering correctly in html:

html 
![image](https://user-images.githubusercontent.com/10260230/126697185-345fb3ee-9c15-4f75-a2d5-e542e3603475.png)

razor & liquid
![image](https://user-images.githubusercontent.com/10260230/126697212-4ece670b-4563-4770-b32a-f17e95876cd9.png)
