### PR TITLE
Remove ' as an auto-closing pair for Rust

### DIFF
--- a/src/rust/rust.ts
+++ b/src/rust/rust.ts
@@ -19,7 +19,6 @@ export const conf: languages.LanguageConfiguration = {
 		{ open: '[', close: ']' },
 		{ open: '{', close: '}' },
 		{ open: '(', close: ')' },
-		{ open: "'", close: "'", notIn: ['string', 'comment'] },
 		{ open: '"', close: '"', notIn: ['string'] }
 	],
 	surroundingPairs: [


### PR DESCRIPTION
They're bad for Rust lifetimes.

Fixes https://github.com/microsoft/monaco-editor/issues/2585.