### PR TITLE
Adds `strict` keyword to Pascal language

### DIFF
--- a/src/pascal/pascal.ts
+++ b/src/pascal/pascal.ts
@@ -128,6 +128,7 @@ export const language = <languages.IMonarchLanguage>{
 		'shr',
 		'specialize',
 		'stored',
+		'strict',
 		'then',
 		'threadvar',
 		'to',


### PR DESCRIPTION
This PR adds support to the `strict` keyword to Pascal language.

This keyword is defined in FreePascal (https://www.freepascal.org/docs-html/current/ref/refsu3.html#x14-130001.3.3) and Delphi (http://docwiki.embarcadero.com/RADStudio/Sydney/en/Classes_and_Objects_(Delphi))