### PR TITLE
Replace // with # for line comments

### DIFF
--- a/src/hcl/hcl.ts
+++ b/src/hcl/hcl.ts
@@ -7,7 +7,7 @@ import type { languages } from '../fillers/monaco-editor-core';
 
 export const conf: languages.LanguageConfiguration = {
 	comments: {
-		lineComment: '//',
+		lineComment: '#',
 		blockComment: ['/*', '*/']
 	},
 	brackets: [


### PR DESCRIPTION
The Terraform HCL documentation states that the # is the preferred and default setting for single line comments:
https://www.terraform.io/docs/language/syntax/configuration.html#comments