### PR TITLE
SystemVerilog: Adding better syntax highlighting for primitive table definitions

### DIFF
--- a/src/systemverilog/systemverilog.test.ts
+++ b/src/systemverilog/systemverilog.test.ts
@@ -1180,5 +1180,88 @@ testTokenization('systemverilog', [
 				{ startIndex: 49, type: 'delimiter.sv' }
 			]
 		}
+	],
+	// table
+	[
+		{
+			line: 'table',
+			tokens: [{ startIndex: 0, type: 'keyword.table.sv' }]
+		},
+		{
+			line: '  //  clk  d    q    q+',
+			tokens: [
+				{ startIndex: 0, type: '' },
+				{ startIndex: 2, type: 'comment.sv' }
+			]
+		},
+		{
+			line: '  r  ?  0 : ? : - ;',
+			tokens: [
+				{ startIndex: 0, type: '' },
+				{ startIndex: 2, type: 'variable.predefined.sv' },
+				{ startIndex: 3, type: '' },
+				{ startIndex: 5, type: 'variable.predefined.sv' },
+				{ startIndex: 6, type: '' },
+				{ startIndex: 8, type: 'variable.predefined.sv' },
+				{ startIndex: 9, type: '' },
+				{ startIndex: 10, type: 'delimiter.sv' },
+				{ startIndex: 11, type: '' },
+				{ startIndex: 12, type: 'variable.predefined.sv' },
+				{ startIndex: 13, type: '' },
+				{ startIndex: 14, type: 'delimiter.sv' },
+				{ startIndex: 15, type: '' },
+				{ startIndex: 16, type: 'variable.predefined.sv' },
+				{ startIndex: 17, type: '' },
+				{ startIndex: 18, type: 'delimiter.sv' }
+			]
+		},
+		{
+			line: '  0 x (01) : 0 : 1; // Comment ',
+			tokens: [
+				{ startIndex: 0, type: '' },
+				{ startIndex: 2, type: 'variable.predefined.sv' },
+				{ startIndex: 3, type: '' },
+				{ startIndex: 4, type: 'variable.predefined.sv' },
+				{ startIndex: 5, type: '' },
+				{ startIndex: 6, type: 'delimiter.parenthesis.sv' },
+				{ startIndex: 7, type: 'variable.predefined.sv' },
+				{ startIndex: 9, type: 'delimiter.parenthesis.sv' },
+				{ startIndex: 10, type: '' },
+				{ startIndex: 11, type: 'delimiter.sv' },
+				{ startIndex: 12, type: '' },
+				{ startIndex: 13, type: 'variable.predefined.sv' },
+				{ startIndex: 14, type: '' },
+				{ startIndex: 15, type: 'delimiter.sv' },
+				{ startIndex: 16, type: '' },
+				{ startIndex: 17, type: 'variable.predefined.sv' },
+				{ startIndex: 18, type: 'delimiter.sv' },
+				{ startIndex: 19, type: '' },
+				{ startIndex: 20, type: 'comment.sv' }
+			]
+		},
+		{
+			line: '0 0 1 : 0 : 1 ;',
+			tokens: [
+				{ startIndex: 0, type: 'variable.predefined.sv' },
+				{ startIndex: 1, type: '' },
+				{ startIndex: 2, type: 'variable.predefined.sv' },
+				{ startIndex: 3, type: '' },
+				{ startIndex: 4, type: 'variable.predefined.sv' },
+				{ startIndex: 5, type: '' },
+				{ startIndex: 6, type: 'delimiter.sv' },
+				{ startIndex: 7, type: '' },
+				{ startIndex: 8, type: 'variable.predefined.sv' },
+				{ startIndex: 9, type: '' },
+				{ startIndex: 10, type: 'delimiter.sv' },
+				{ startIndex: 11, type: '' },
+				{ startIndex: 12, type: 'variable.predefined.sv' },
+				{ startIndex: 13, type: '' },
+				{ startIndex: 14, type: 'delimiter.sv' }
+			]
+		},
+		{
+			line: 'endtable',
+			tokens: [{ startIndex: 0, type: 'keyword.endtable.sv' }]
+		}
 	]
 ]);

--- a/src/systemverilog/systemverilog.ts
+++ b/src/systemverilog/systemverilog.ts
@@ -449,6 +449,10 @@ export const language = <languages.IMonarchLanguage>{
 								token: 'keyword.$2',
 								next: '@module_instance'
 							},
+							table: {
+								token: 'keyword.$2',
+								next: '@table'
+							},
 							'@keywords': { token: 'keyword.$2' },
 							'@default': {
 								token: 'identifier',
@@ -468,7 +472,7 @@ export const language = <languages.IMonarchLanguage>{
 			// identifiers and keywords
 			{ include: '@identifier_or_keyword' },
 
-			// whitespace
+			// whitespace and comments
 			{ include: '@whitespace' },
 
 			// (* attributes *).
@@ -589,6 +593,14 @@ export const language = <languages.IMonarchLanguage>{
 					{ token: 'string.include.identifier', next: '@pop' }
 				]
 			]
+		],
+
+		table: [
+			{ include: '@whitespace' },
+			[/[()]/, '@brackets'],
+			[/[:;]/, 'delimiter'],
+			[/[01\-*?xXbBrRfFpPnN]/, 'variable.predefined'],
+			['endtable', 'keyword.endtable', '@pop']
 		]
 	}
 };


### PR DESCRIPTION
Adding better syntax highlighting for user-defined primitive tables, which have their own list of symbols defined by the language (0, 1, x, ?, b, -, *, r, f, p, n).  Currently the identifiers and numbers are getting highlighted which looks OK, but adding a uniform style looks better.

Before:
<img width="240" alt="sv_table_before" src="https://user-images.githubusercontent.com/7417975/136706201-5dd7c7bb-652a-4d5b-b3b1-01582929acce.png">

After:
<img width="243" alt="sv_table_after" src="https://user-images.githubusercontent.com/7417975/136706209-47afbf40-3a16-419c-8d94-52f14facedf9.png">

I'm participating in [Hacktoberfest](https://hacktoberfest.digitalocean.com/), so if this PR looks good and you don't mind, could you add the `hacktoberfest-accepted` label to it?  Thanks a lot!